### PR TITLE
Include license file in sdists and wheels

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 include README.rst
 include examples/*.py
 include acoular/xml/*.*
+include LICENSE
+include AUTHORS.rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
The terms of the BSD 3 Clause license require the license text be included with all copies of the software.