### PR TITLE
Include tests in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,9 @@
-include README.rst
-include examples/*.py
-include acoular/xml/*.*
 include LICENSE
-include AUTHORS.rst
+include *.rst
+
+recursive-include acoular *
+
+graft examples
+
+graft tests
+include importtest.py


### PR DESCRIPTION
This makes it easier for downstream packagers to make sure they have the package set up correctly