### PR TITLE
Switching from arange to linspace in SineGenerator

### DIFF
--- a/acoular/signals.py
+++ b/acoular/signals.py
@@ -18,7 +18,7 @@
 
 # imports from other packages
 from __future__ import print_function, division
-from numpy import pi, arange, sin, sqrt, repeat, tile, log, zeros
+from numpy import pi, sin, sqrt, repeat, tile, log, zeros, linspace
 from numpy.random import RandomState
 from traits.api import HasPrivateTraits, Trait, Float, Int, CLong, Bool, \
 Property, cached_property, Delegate
@@ -230,7 +230,7 @@ class SineGenerator( SignalGenerator ):
         array of floats
             The resulting signal as an array of length :attr:`~SignalGenerator.numsamples`.
         """
-        t = arange(self.numsamples, dtype=float)/self.sample_freq
+        t = linspace(0,self.numsamples/self.sample_freq,self.numsamples, dtype = float)
         return self.amplitude * sin(2*pi*self.freq * t + self.phase)
 
 


### PR DESCRIPTION
I identified one error in creating the time vector in the SineGenerator method. To create the time vector is used the arange method instead linspace, and because of that, the generated signal will be not a clean sine (or pure tone).

The comparisons using linspace and arange can be seen in this notebook from google colab: https://colab.research.google.com/drive/1fflSEMuR46BnDc1iX0hZZ0OqknWK6uVZ?usp=sharing

I plotted the graphics in the frequency domain and in them you can see that the use of the arange generates several unwanted artifacts.