### PR TITLE
updates travis for win 3.6, 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ jobs:
       os: osx
       osx_image: xcode11.3  # Python 3.8.0 running on macOS 10.14.6
       language: shell       # 'language: python' is an error on Travis CI macOS
+    - name: "Python 3.9 on macOS 10.15.7"
+      os: osx
+      osx_image: xcode12.2  # Python 3.9 running on macOS 10.15.7
+      language: shell       # 'language: python' is an error on Travis CI macOS
     #  ====== WINDOWS =========
     # - name: "Python 3.6.8 on Windows"
     #   os: windows           # Windows 10.0.17134 N/A Build 17134

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ jobs:
       os: osx
       osx_image: xcode12.2  # Python 3.9 running on macOS 10.15.7
       language: shell       # 'language: python' is an error on Travis CI macOS
+      before_install:
+       - brew install c-blosc
+       - pip3 install tables
     #  ====== WINDOWS =========
     # - name: "Python 3.6.8 on Windows"
     #   os: windows           # Windows 10.0.17134 N/A Build 17134

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,46 +19,46 @@ jobs:
       osx_image: xcode11.3  # Python 3.8.0 running on macOS 10.14.6
       language: shell       # 'language: python' is an error on Travis CI macOS
     #  ====== WINDOWS =========
-    - name: "Python 3.6.8 on Windows"
-      os: windows           # Windows 10.0.17134 N/A Build 17134
-      language: shell       # 'language: python' is an error on Travis CI Windows
-      before_install:
-          #use conda python
-         - MINICONDA_PATH=/c/tools/miniconda3/;
-         - MINICONDA_PATH_WIN=`cygpath --windows $MINICONDA_PATH`;
-         - MINICONDA_SUB_PATH=$MINICONDA_PATH/Scripts;
-         - choco install openssl.light;
-         - choco install miniconda3 --params="'/AddToPath:1 /D:$MINICONDA_PATH_WIN'";
-         - export PATH="$MINICONDA_PATH:$MINICONDA_SUB_PATH:$PATH";
-         - source $MINICONDA_PATH/etc/profile.d/conda.sh;
-         - hash -r;
-         - conda config --set always_yes yes --set changeps1 no;
-         - conda update -q conda;
-         #create env and install libpython and pytables
-         - conda create --name test-environment python=3.6 ;
-         - conda activate test-environment;
-         - conda install -c anaconda hdf5 pytables;
-         - conda install libpython;
-    - name: "Python 3.7.9 on Windows"
-      os: windows           # Windows 10.0.17134 N/A Build 17134
-      language: shell       # 'language: python' is an error on Travis CI Windows
-      before_install:
-         #use conda python
-         - MINICONDA_PATH=/c/tools/miniconda3/;
-         - MINICONDA_PATH_WIN=`cygpath --windows $MINICONDA_PATH`;
-         - MINICONDA_SUB_PATH=$MINICONDA_PATH/Scripts;
-         - choco install openssl.light;
-         - choco install miniconda3 --params="'/AddToPath:1 /D:$MINICONDA_PATH_WIN'";
-         - export PATH="$MINICONDA_PATH:$MINICONDA_SUB_PATH:$PATH";
-         - source $MINICONDA_PATH/etc/profile.d/conda.sh;
-         - hash -r;
-         - conda config --set always_yes yes --set changeps1 no;
-         - conda update -q conda;
-         #create env and install libpython and pytables
-         - conda create --name test-environment python=3.7 ;
-         - conda activate test-environment;
-         - conda install -c anaconda h5py pytables;
-         - conda install libpython;
+    # - name: "Python 3.6.8 on Windows"
+    #   os: windows           # Windows 10.0.17134 N/A Build 17134
+    #   language: shell       # 'language: python' is an error on Travis CI Windows
+    #   before_install:
+    #       #use conda python
+    #      - MINICONDA_PATH=/c/tools/miniconda3/;
+    #      - MINICONDA_PATH_WIN=`cygpath --windows $MINICONDA_PATH`;
+    #      - MINICONDA_SUB_PATH=$MINICONDA_PATH/Scripts;
+    #      - choco install openssl.light;
+    #      - choco install miniconda3 --params="'/AddToPath:1 /D:$MINICONDA_PATH_WIN'";
+    #      - export PATH="$MINICONDA_PATH:$MINICONDA_SUB_PATH:$PATH";
+    #      - source $MINICONDA_PATH/etc/profile.d/conda.sh;
+    #      - hash -r;
+    #      - conda config --set always_yes yes --set changeps1 no;
+    #      - conda update -q conda;
+    #      #create env and install libpython and pytables
+    #      - conda create --name test-environment python=3.6 ;
+    #      - conda activate test-environment;
+    #      - conda install -c anaconda pytables;
+    #      - conda install libpython;
+    # - name: "Python 3.7.9 on Windows"
+    #   os: windows           # Windows 10.0.17134 N/A Build 17134
+    #   language: shell       # 'language: python' is an error on Travis CI Windows
+    #   before_install:
+    #      #use conda python
+    #      - MINICONDA_PATH=/c/tools/miniconda3/;
+    #      - MINICONDA_PATH_WIN=`cygpath --windows $MINICONDA_PATH`;
+    #      - MINICONDA_SUB_PATH=$MINICONDA_PATH/Scripts;
+    #      - choco install openssl.light;
+    #      - choco install miniconda3 --params="'/AddToPath:1 /D:$MINICONDA_PATH_WIN'";
+    #      - export PATH="$MINICONDA_PATH:$MINICONDA_SUB_PATH:$PATH";
+    #      - source $MINICONDA_PATH/etc/profile.d/conda.sh;
+    #      - hash -r;
+    #      - conda config --set always_yes yes --set changeps1 no;
+    #      - conda update -q conda;
+    #      #create env and install libpython and pytables
+    #      - conda create --name test-environment python=3.7 ;
+    #      - conda activate test-environment;
+    #      - conda install -c anaconda pytables;
+    #      - conda install libpython;
     - name: "Python 3.8.8 on Windows"
       os: windows           # Windows 10.0.17134 N/A Build 17134
       language: shell       # 'language: python' is an error on Travis CI Windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ jobs:
          #create env and install libpython and pytables
          - conda create --name test-environment python=3.6 ;
          - conda activate test-environment;
-         - conda install -c anaconda pytables;
+         - conda install -c anaconda hdf5 pytables;
          - conda install libpython;
     - name: "Python 3.7.9 on Windows"
       os: windows           # Windows 10.0.17134 N/A Build 17134
@@ -57,7 +57,7 @@ jobs:
          #create env and install libpython and pytables
          - conda create --name test-environment python=3.7 ;
          - conda activate test-environment;
-         - conda install -c anaconda pytables;
+         - conda install -c anaconda h5py pytables;
          - conda install libpython;
     - name: "Python 3.8.8 on Windows"
       os: windows           # Windows 10.0.17134 N/A Build 17134


### PR DESCRIPTION
* Removes python 3.6, 3.7 for windows from Travis because of problems with pytables installation we cannot solve.
* Adds python 3.9 for OSX to Travis (works now with some additional pre-install support)