### PR TITLE
Draft: Use Context Manager

### DIFF
--- a/acoular/sources.py
+++ b/acoular/sources.py
@@ -207,9 +207,9 @@ class TimeSamples( SamplesGenerator ):
                 for nodename, nodedata in file.get_child_nodes('/metadata'):
                     self.metadata[nodename] = nodedata
 
-    def _set_data(self, value):
+    def _set_data(self, data):
         self.name = ''
-        self._data = value
+        self._data = data
         self._initialize_timedata()
 
     def _get_data_by_reference(self, file):

--- a/acoular/sources.py
+++ b/acoular/sources.py
@@ -180,11 +180,13 @@ class TimeSamples( SamplesGenerator ):
             self._initialize_timedata()
             self._load_metadata()
         else:
+            self.metadata = {}
             self.numsamples = 0
             self.numchannels = 0
             self.sample_freq = 1.0
-            msg = f"No such file: {self.name}"
-            raise OSError(msg)
+            if self.name != '':
+                msg = f"No such file: {self.name}"
+                raise OSError(msg)
 
     def _initialize_timedata( self ):
         """Initializes the attributes `numchannels`, `numsamples` and `sample_freq` (Only for internal use)."""
@@ -203,12 +205,8 @@ class TimeSamples( SamplesGenerator ):
                 for nodename, nodedata in file.get_child_nodes('/metadata'):
                     self.metadata[nodename] = nodedata
 
-    def _reset_file_attributes(self):
-        self.name = ''
-        self.metadata = {}
-
     def _set_data(self, value):
-        self._reset_file_attributes()
+        self.name = ''
         self._data = value
         self._initialize_timedata()
 

--- a/acoular/sources.py
+++ b/acoular/sources.py
@@ -163,7 +163,9 @@ class TimeSamples( SamplesGenerator ):
             yield None
 
     def _get__datachecksum( self ):
-        return self.data[0,:].sum()
+        with self.h5f as file:
+            data = self._get_data_by_reference(file)
+            return data[0,:].sum()
 
     @cached_property
     def _get_digest( self ):

--- a/acoular/sources.py
+++ b/acoular/sources.py
@@ -211,7 +211,7 @@ class TimeSamples( SamplesGenerator ):
         self._initialize_timedata()
 
     def _get_data_by_reference(self, file):
-        """Return the data array by reference"""
+        """Return the data array by reference."""
         if file is not None:
             return file.get_data_by_reference('time_data')
         return self._data

--- a/examples/acoular_demo.py
+++ b/examples/acoular_demo.py
@@ -21,7 +21,7 @@ Source Location        Level
 ====== =============== ======
 """
 
-from os import path
+from pathlib import Path
 from acoular import __file__ as bpath, MicGeom, WNoiseGenerator, PointSource,\
  Mixer, WriteH5, TimeSamples, PowerSpectra, RectGrid, SteeringVector,\
  BeamformerBase, L_p
@@ -31,7 +31,7 @@ from pylab import figure, plot, axis, imshow, colorbar, show
 sfreq = 51200 
 duration = 1
 nsamples = duration*sfreq
-micgeofile = path.join(path.split(bpath)[0],'xml','array_64.xml')
+micgeofile = Path(bpath).parent / 'xml' / 'array_64.xml'
 h5savefile = 'three_sources.h5'
 
 # generate test data, in real life this would come from an array measurement


### PR DESCRIPTION
I would like to draft some changes regarding the handling of files. Currently, the `TimeSamples` class (and other classes) holds an open file via the `h5f` file trait. This becomes a problem when the same file should be overwritten or changed by some other class (e.g. the `WriteH5` class) but the `TimeSamples` instance still exists. When running the acoular_demo.py twice in an IDE would result in the error:  

```
HDF5ExtError: HDF5 error back trace

  File "H5F.c", line 660, in H5Fcreate
    unable to synchronously create file
  File "H5F.c", line 614, in H5F__create_api_common
    unable to create file
  File "H5VLcallback.c", line 3605, in H5VL_file_create
    file create failed
  File "H5VLcallback.c", line 3571, in H5VL__file_create
    file create failed
  File "H5VLnative_file.c", line 94, in H5VL__native_file_create
    unable to create file
  File "H5Fint.c", line 1833, in H5F_open
    unable to truncate a file which is already open

End of HDF5 error back trace

Unable to open/create file 'three_sources.h5'
```

I suggest that files stay open only as long they are used, and suggest to refactor the code the following: 

* The `h5f` trait becomes a `Property,` and the getter method is a context manager handling the opening and closing of the file. Especially the latter is important when the generator finishes 
* The `data` trait becomes a `Property` which has a `set` method (assign an array of data instead of reading from file) and a `get` method. The latter returns a copy of the time data. In addition, the `get_data_by_reference` only yields the reference to the data (this is then used inside the result generator).
* use `pathlib` instead of `os.path` module 
* make some internally used methods private (`_load_data`, `_load_metadata`)