### PR TITLE
fix `enforce-label` job

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -26,6 +26,7 @@ jobs:
     steps:
       - uses: yogevbd/enforce-label-action@2.2.2
         with:
+          REQUIRED_LABELS_ANY: "caching,ci,docs,enhancement,linting,maintenance,new feature,sinus,tests"
           REQUIRED_LABELS_ANY_DESCRIPTION: Assign at least one label with to this pull request
           BANNED_LABELS: bug
           BANNED_LABELS_DESCRIPTION: The 'bug' label should only be used on issues


### PR DESCRIPTION
I just realized that labels were not correctly enforced by the CI job, because CI is not failing for all the new PRs. This one should fix it now.