### PR TITLE
add support for Python 3.12

### DIFF
--- a/.github/actions/setup-hatch/action.yml
+++ b/.github/actions/setup-hatch/action.yml
@@ -4,7 +4,7 @@ inputs:
   python-version:
     description: 'The Python version'
     required: false
-    default: '3.11'
+    default: '3.12'
 runs:
   using: composite
   steps:

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -3,6 +3,8 @@ name: GitHub
 on:
   pull_request:
     branches: master
+  pull_request_target:
+    branches: master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -3,8 +3,6 @@ name: GitHub
 on:
   pull_request:
     branches: master
-  pull_request_target:
-    branches: master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up hatch
         uses: ./.github/actions/setup-hatch
       - name: Generate coverage report
-        run: hatch -v run +py=3.11 tests:coverage
+        run: hatch -v run +py=3.12 tests:coverage
 
   alls-green:
     name: Tests green?

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-13, windows-latest]
-        python-version: ['3.7', '3.8', '3.9','3.10','3.11']
+        python-version: ['3.7', '3.8', '3.9','3.10','3.11','3.12']
     steps:
       - name: Check out a copy of the repository
         uses: actions/checkout@v4

--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -6,7 +6,7 @@ Depending on your operating system and python distribution, there are different 
 Requirements
 ------------
 
-Acoular runs under 64bit Windows, Linux and MacOS, and needs Python 3.7, 3.8, 3.9, 3.10 or 3.11
+Acoular runs under 64bit Windows, Linux and MacOS, and needs Python 3.7, 3.8, 3.9, 3.10, 3.11 or 3.12
 
 Upon installation using options 1 or 2 below, all necessary dependencies will also be installed.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 name = "acoular"
 version = "24.03"
 description = "Python library for acoustic beamforming"
-requires-python = ">=3.7,<=11"
+requires-python = ">=3.7,<=12"
 authors = [
     {name = "Acoular Development Team", email = "info@acoular.org"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
     "numba",
@@ -89,7 +90,7 @@ dependencies = [
 ]
 
 [[tool.hatch.envs.tests.matrix]]
-python = ["3.7", "3.8", "3.9", "3.10", "3.11"]
+python = ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
 [tool.hatch.envs.tests.scripts]
 import = ["python -c \"import acoular\""]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ config-path = [".ruff.toml"]
 
 [tool.hatch.envs.docs]
 platforms = ["linux"]
-python = "3.11"
+python = "3.12"
 dependencies = [
     "ipython",
     "graphviz",


### PR DESCRIPTION
Acoular is now compatible with Python version 3.12
* extend tests to 3.12
* use Python 3.12 as default for CI setup