### PR TITLE
CI for TestPyPI and PyPI

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,45 @@
+name: Publish Python 🐍 distribution 📦 PyPI
+
+on: 
+  workflow_dispatch:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+  
+    steps:
+    - name: Check out a copy of the repository
+      uses: actions/checkout@v4
+    - name: Set up hatch
+      uses: ./.github/actions/setup-hatch
+    - name: Build a binary wheel and a source tarball
+      run: hatch build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/        
+
+  publish-to-testpypi:
+    name: Publish Python 🐍 distribution 📦 to PyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/acoular
+
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -4,44 +4,44 @@ on:
   workflow_dispatch:
     branches: [ "*" ] 
 
-  jobs:
-    build:
-      name: Build distribution 📦
-      runs-on: ubuntu-latest
-    
-      steps:
-      - name: Check out a copy of the repository
-        uses: actions/checkout@v4
-      - name: Set up hatch
-        uses: ./.github/actions/setup-hatch
-      - name: Build a binary wheel and a source tarball
-        run: hatch build
-      - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
-        with:
-          name: python-package-distributions
-          path: dist/        
+jobs:
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+  
+    steps:
+    - name: Check out a copy of the repository
+      uses: actions/checkout@v4
+    - name: Set up hatch
+      uses: ./.github/actions/setup-hatch
+    - name: Build a binary wheel and a source tarball
+      run: hatch build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/        
 
-    publish-to-testpypi:
-      name: Publish Python 🐍 distribution 📦 to TestPyPI
-      needs:
-      - build
-      runs-on: ubuntu-latest
+  publish-to-testpypi:
+    name: Publish Python 🐍 distribution 📦 to TestPyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
 
-      environment:
-        name: testpypi
-        url: https://test.pypi.org/p/acoular
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/acoular
 
-      permissions:
-        id-token: write  # IMPORTANT: mandatory for trusted publishing
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
 
-      steps:
-      - name: Download all the dists
-        uses: actions/download-artifact@v4
-        with:
-          name: python-package-distributions
-          path: dist/
-      - name: Publish distribution 📦 to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/          
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/          

--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -3,6 +3,8 @@ name: Publish Python 🐍 distribution 📦 TestPyPI
 on: 
   push:
     branches: [ "*" ] 
+  workflow_dispatch:
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -1,8 +1,6 @@
 name: Publish Python 🐍 distribution 📦 TestPyPI
 
 on: 
-  push:
-    branches: [ "*" ]
   workflow_dispatch:
     branches: [ master ]
 

--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -3,9 +3,6 @@ name: Publish Python 🐍 distribution 📦 TestPyPI
 on: 
   workflow_dispatch:
     branches: [ master ]
-  push:
-    branches: [ "*" ]
-
 
 jobs:
   build:

--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -1,7 +1,7 @@
 name: Publish Python 🐍 distribution 📦 TestPyPI
 
 on: 
-  workflow_dispatch:
+  push:
     branches: [ "*" ] 
 
 jobs:

--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -1,8 +1,6 @@
 name: Publish Python 🐍 distribution 📦 TestPyPI
 
 on: 
-  push:
-    branches: [ "*" ] 
   workflow_dispatch:
     branches: [ master ]
 
@@ -17,7 +15,7 @@ jobs:
     - name: Set up hatch
       uses: ./.github/actions/setup-hatch
     - name: Build a binary wheel and a source tarball
-      run: hatch build
+      run: hatch build 
     - name: Store the distribution packages
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -3,6 +3,9 @@ name: Publish Python 🐍 distribution 📦 TestPyPI
 on: 
   workflow_dispatch:
     branches: [ master ]
+  push:
+    branches: [ "*" ]
+
 
 jobs:
   build:

--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -1,0 +1,47 @@
+name: Publish Python 🐍 distribution 📦 TestPyPI
+
+on: 
+  workflow_dispatch:
+    branches: [ "*" ] 
+
+  jobs:
+    build:
+      name: Build distribution 📦
+      runs-on: ubuntu-latest
+    
+      steps:
+      - name: Check out a copy of the repository
+        uses: actions/checkout@v4
+      - name: Set up hatch
+        uses: ./.github/actions/setup-hatch
+      - name: Build a binary wheel and a source tarball
+        run: hatch build
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/        
+
+    publish-to-testpypi:
+      name: Publish Python 🐍 distribution 📦 to TestPyPI
+      needs:
+      - build
+      runs-on: ubuntu-latest
+
+      environment:
+        name: testpypi
+        url: https://test.pypi.org/p/acoular
+
+      permissions:
+        id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+      steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution 📦 to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/          

--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -1,6 +1,8 @@
 name: Publish Python 🐍 distribution 📦 TestPyPI
 
 on: 
+  push:
+    branches: [ "*" ]
   workflow_dispatch:
     branches: [ master ]
 

--- a/README.md
+++ b/README.md
@@ -113,4 +113,5 @@ interpolation='bicubic')
 colorbar()
 ```
 
+
 ![result](https://github.com/acoular/acoular/blob/master/docs/source/get_started/three_source_py3_colormap.png)

--- a/README.md
+++ b/README.md
@@ -114,4 +114,4 @@ colorbar()
 ```
 
 
-![result](https://github.com/acoular/acoular/blob/master/docs/source/get_started/three_source_py3_colormap.png)
+![result](https://github.com/acoular/acoular/blob/master/docs/source/get_started/three_source_py3_colormap.png?raw=true)

--- a/README.md
+++ b/README.md
@@ -113,4 +113,4 @@ interpolation='bicubic')
 colorbar()
 ```
 
-![result](https://github.com/acoular/acoular/blob/master/docs/source/get_started/three_source_py3_colormap.png?raw=true)
+![result](https://github.com/acoular/acoular/blob/master/docs/source/get_started/three_source_py3_colormap.png)

--- a/README.md
+++ b/README.md
@@ -30,15 +30,6 @@ It is aimed at applications in acoustic testing. Multichannel data recorded by a
 - parallel (multithreaded) implementation with Numba for most algorithms
 - easily extendable with new algorithms
 
-# Announcements
-
-**Acoular Workshop 2024**
-
-Join us on **June 12-13, 2024** for a comprehensive free workshop on Acoular. 
-The workshop will be held at TU Berlin Department of Engineering and is suitable for first time users as well as for experienced Acoular users.
-
-To secure your spot at the workshop and to access additional information, kindly **register here**: [Acoular Workshop Registration](https://www.tu.berlin/en/event-details/events/event/018c1020-419d-70b6-abcf-2220015bd233)
-
 # License
 Acoular is licensed under the BSD 3-clause. See [LICENSE](LICENSE)
 
@@ -122,4 +113,4 @@ interpolation='bicubic')
 colorbar()
 ```
 
-![result](https://github.com/acoular/acoular/blob/master/docs/source/get_started/three_source_py3_colormap.png)
+![result](https://github.com/acoular/acoular/blob/master/docs/source/get_started/three_source_py3_colormap.png?raw=true)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It is aimed at applications in acoustic testing. Multichannel data recorded by a
 - frequency domain deconvolution algorithms: DAMAS, DAMAS+, Clean, CleanSC, orthogonal deconvolution
 - frequency domain inverse methods: CMF (covariance matrix fitting), general inverse beamforming, SODIX
 - time domain methods: delay & sum beamforming, CleanT deconvolution
-- time domain methods applicable for moving source with arbitrary trajectory (linear, circular, arbitrarily 3D curved), 
+- time domain methods applicable for moving sources with arbitrary trajectory (linear, circular, arbitrarily 3D curved), 
 - frequency domain methods for rotating sources via virtual array rotation for arbitrary arrays and with different interpolation techniques
 - 1D, 2D and 3D mapping grids for all methods
 - gridless option for orthogonal deconvolution
@@ -53,7 +53,7 @@ and our [software](https://zenodo.org/doi/10.5281/zenodo.3690794):
 Acoular runs under Linux, Windows and MacOS and needs Numpy, Scipy, Traits, scikit-learn, pytables, Numba packages available. 
 Matplotlib is needed for some of the examples.
 
-If you want to use input from a soundcard hardware, you will also need to install the [sounddevice](https://python-sounddevice.readthedocs.io/en/0.3.12/installation.html) package. Some solvers for the CMF method need [Pylops](https://pylops.readthedocs.io/en/stable/installation.html).
+If you want to use input from a soundcard, you will also need to install the [sounddevice](https://python-sounddevice.readthedocs.io/en/0.3.12/installation.html) package. Some solvers for the CMF method need [Pylops](https://pylops.readthedocs.io/en/stable/installation.html).
 
 # Installation
 
@@ -61,13 +61,13 @@ Acoular can be installed via [conda](https://docs.conda.io/en/latest/), which is
 
     conda install -c acoular acoular
 
-This will install Acoular in your Anaconda Python enviroment and make the Acoular library available from Python. In addition, this will install all dependencies (those other packages mentioned above) if they are not already present on your system. 
+This will install Acoular in your Anaconda Python environment and make the Acoular library available from Python. In addition, this will install all dependencies (those other packages mentioned above) if they are not already present on your system. 
 
 A second option is to install Acoular via [pip](https://pip.pypa.io/en/stable/). It is recommended to use a dedicated [virtual environment](https://virtualenv.pypa.io/en/latest/) and then run
 
     pip install acoular
 
-For more detailed install instructions see the [documentation](https://acoular.org/install/index.html).
+For more detailed installation instructions, see the [documentation](https://acoular.org/install/index.html).
 
 # Documentation and help
 Documentation is available [here](https://acoular.org) with a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "acoular"
-version = "0.2"
+version = "24.05"
 description = "Python library for acoustic beamforming"
 requires-python = ">=3.8,<=12"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,8 @@ full = [
 ]
 
 [project.urls]
-homepage = "http://acoular.org"
-documentation = "http://acoular.org"
+homepage = "https://acoular.org"
+documentation = "https://acoular.org"
 repository = "https://github.com/acoular/acoular"
 
 [build-system]
@@ -104,9 +104,8 @@ platform.windows.pre-install-commands = ['systeminfo']
 
 
 [tool.hatch.build.targets.sdist]
-exclude = [
-  "/.github",
-  "/docs",
+include = [
+  "/acoular",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,3 +101,13 @@ coverage = ["test --cov=acoular"]
 platform.linux.pre-install-commands = ['cat /proc/cpuinfo']
 platform.macos.pre-install-commands = ['sysctl -a machdep.cpu']
 platform.windows.pre-install-commands = ['systeminfo']
+
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.github",
+  "/docs",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["acoular/acoular"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "acoular"
-version = "24.05"
+version = "24.05_test"
 description = "Python library for acoustic beamforming"
 requires-python = ">=3.8,<=12"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "acoular"
-version = "24.05"
+version = "0.3"
 description = "Python library for acoustic beamforming"
 requires-python = ">=3.8,<=12"
 authors = [
@@ -110,4 +110,4 @@ exclude = [
 ]
 
 [tool.hatch.build.targets.wheel]
-packages = ["acoular/acoular"]
+packages = ["acoular"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "acoular"
-version = "0.4"
+version = "24.05"
 description = "Python library for acoustic beamforming"
 requires-python = ">=3.8,<=12"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,8 @@ full = [
 ]
 
 [project.urls]
-homepage = "www.acoular.org"
-documentation = "www.acoular.org"
+homepage = "http://acoular.org"
+documentation = "http://acoular.org"
 repository = "https://github.com/acoular/acoular"
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ platform.windows.pre-install-commands = ['systeminfo']
 [tool.hatch.build.targets.sdist]
 exclude = [
   "/.github",
-  "/docs",
+  "/docs/build",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "acoular"
-version = "24.05"
+version = "0.4"
 description = "Python library for acoustic beamforming"
 requires-python = ">=3.8,<=12"
 authors = [
@@ -54,8 +54,8 @@ full = [
 ]
 
 [project.urls]
-homepage = "https://acoular.org"
-documentation = "https://acoular.org"
+homepage = "www.acoular.org"
+documentation = "www.acoular.org"
 repository = "https://github.com/acoular/acoular"
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "acoular"
-version = "0.3"
+version = "24.05"
 description = "Python library for acoustic beamforming"
 requires-python = ">=3.8,<=12"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "acoular"
-version = "24.05_test"
+version = "0.1"
 description = "Python library for acoustic beamforming"
 requires-python = ">=3.8,<=12"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "acoular"
-version = "0.1"
+version = "0.2"
 description = "Python library for acoustic beamforming"
 requires-python = ">=3.8,<=12"
 authors = [
@@ -106,7 +106,7 @@ platform.windows.pre-install-commands = ['systeminfo']
 [tool.hatch.build.targets.sdist]
 exclude = [
   "/.github",
-  "/docs/build",
+  "/docs",
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
* uses hatch to build wheel and tarball
* adds CI workflows to build and deploy to TestPyPI and PyPI 
* fixes some typos and problems with links and images in README.md
* successful test publishing on TestPyPI -> https://test.pypi.org/project/acoular/ (I had to temporarily use a different version number, because after the upload the respective version is blocked and cannot be used again)

One thing I wasn't sure about was how we should handle it is what the tarball archive needs to include. Probably, the package could be smaller if we exclude some directories such as the tests directory for example. 

One flaw is that the installation with testpypi does not work out of the box, as some package distributions that Acoular depends on are not on TestPyPI. Therefore I had to check locally if the wheels and tarball are correct.
