### PR TITLE
Implement a lazy result array for BeamformerBase derived classes

### DIFF
--- a/acoular/fbeamform.py
+++ b/acoular/fbeamform.py
@@ -261,7 +261,7 @@ class SteeringVector(HasPrivateTraits):
 class LazyBfResult:
     """Manages lazy per-frequency evaluation."""
 
-    # Internal helper class which works togther with BeamformerBase to provide
+    # Internal helper class which works together with BeamformerBase to provide
     # calculation on demand; provides an 'intelligent' [] operator. This is
     # implemented as an extra class instead of as a method of BeamformerBase to
     # properly control the BeamformerBase.result attribute. Might be migrated to
@@ -616,8 +616,6 @@ class BeamformerBase(HasPrivateTraits):
         if len(freq) == 0:
             return None
 
-        indices = self.freq_data.indices
-
         if num == 0:
             # single frequency line
             ind = searchsorted(freq, f)
@@ -634,14 +632,6 @@ class BeamformerBase(HasPrivateTraits):
                         f'Queried frequency ({f:g} Hz) not in set of '
                         'discrete FFT sample frequencies. '
                         f'Using frequency {freq[ind]:g} Hz instead.',
-                        Warning,
-                        stacklevel=2,
-                    )
-                if ind not in indices:
-                    warn(
-                        'Beamforming result may not have been calculated '
-                        'for queried frequency. Check '
-                        'freq_data.ind_low and freq_data.ind_high!',
                         Warning,
                         stacklevel=2,
                     )
@@ -667,14 +657,6 @@ class BeamformerBase(HasPrivateTraits):
                 h = zeros_like(res[0])
             else:
                 h = sum(res[ind1:ind2], 0)
-                if not ((ind1 in indices) and (ind2 in indices)):
-                    warn(
-                        'Beamforming result may not have been calculated '
-                        'for all queried frequencies. Check '
-                        'freq_data.ind_low and freq_data.ind_high!',
-                        Warning,
-                        stacklevel=2,
-                    )
         if isinstance(self, BeamformerAdaptiveGrid):
             return h
         if isinstance(self, BeamformerSODIX):
@@ -686,7 +668,7 @@ class BeamformerBase(HasPrivateTraits):
 
         Parameters
         ----------
-        sector: aray of floats or :class:`~acoular.grids.Sector`
+        sector: array of floats or :class:`~acoular.grids.Sector`
             either an array, tuple or list with arguments for the 'indices'
             method of a :class:`~acoular.grids.Grid`-derived class
             (e.g. :meth:`RectGrid.indices<acoular.grids.RectGrid.indices>`
@@ -756,7 +738,6 @@ class BeamformerBase(HasPrivateTraits):
                 raise TypeError(
                     msg,
                 )
-            print(frange, irange, self.freq_data._ind_high)
             h = zeros(self._numfreq, dtype=float)
             sl = slice(*irange)
             r = self.result[sl]

--- a/acoular/fbeamform.py
+++ b/acoular/fbeamform.py
@@ -2047,7 +2047,7 @@ class BeamformerSODIX(BeamformerBase):
         # computation. Instead of just solving for only the frequencies in ind, we
         # start with index 1 (minimum frequency) and also check if the result is
         # already computed
-        for i in range(1,ind.max()+1):
+        for i in range(1, ind.max() + 1):
             if not self._fr[i]:
                 # measured csm
                 csm = array(self.freq_data.csm[i], dtype='complex128', copy=1)

--- a/acoular/fbeamform.py
+++ b/acoular/fbeamform.py
@@ -280,7 +280,7 @@ class LazyBfResult:
         if missingind.size:
             self.bf._calc(missingind)
             if self.bf.h5f:
-                self.h5f.flush()
+                self.bf.h5f.flush()
 
         return self.bf._ac.__getitem__(key)
 

--- a/acoular/fbeamform.py
+++ b/acoular/fbeamform.py
@@ -416,18 +416,9 @@ class BeamformerBase(HasPrivateTraits):
     # internal identifier
     digest = Property(depends_on=BEAMFORMER_BASE_DIGEST_DEPENDENCIES)
 
-    # internal identifier
-    ext_digest = Property(
-        depends_on=['digest', 'freq_data.ind_low', 'freq_data.ind_high'],
-    )
-
     @cached_property
     def _get_digest(self):
         return digest(self)
-
-    @cached_property
-    def _get_ext_digest(self):
-        return digest(self, 'ext_digest')
 
     def _get_filecache(self):
         """Function collects cached results from file depending on

--- a/acoular/fbeamform.py
+++ b/acoular/fbeamform.py
@@ -57,6 +57,7 @@ from numpy import (
     hstack,
     index_exp,
     inf,
+    integer,
     invert,
     isscalar,
     linalg,
@@ -272,7 +273,7 @@ class LazyBfResult:
     def __getitem__(self, key):
         # 'intelligent' [] operator checks if results are available and triggers calculation
         sl = index_exp[key][0]
-        if isinstance(sl, int):
+        if isinstance(sl, (int, integer)):
             sl = slice(sl, sl + 1)
         # indices which are missing
         missingind = arange(*sl.indices(self.bf._numfreq))[self.bf._fr[sl] == 0]
@@ -740,7 +741,13 @@ class BeamformerBase(HasPrivateTraits):
         gshape = self.steer.grid.shape
         if num == 0 or frange is None:
             if frange is None:
-                irange = (self.freq_data.ind_low, self.freq_data.ind_high)
+                ind_low = self.freq_data.ind_low
+                ind_high = self.freq_data.ind_high
+                if ind_low is None:
+                    ind_low = 0
+                if ind_high is None:
+                    ind_high = self._numfreq
+                irange = (ind_low, ind_high)
                 num = 0
             elif len(frange) == 2:
                 irange = (searchsorted(self._f, frange[0]), searchsorted(self._f, frange[1]))
@@ -749,6 +756,7 @@ class BeamformerBase(HasPrivateTraits):
                 raise TypeError(
                     msg,
                 )
+            print(frange, irange, self.freq_data._ind_high)
             h = zeros(self._numfreq, dtype=float)
             sl = slice(*irange)
             r = self.result[sl]

--- a/tests/test_beamformer_results.py
+++ b/tests/test_beamformer_results.py
@@ -175,7 +175,7 @@ class acoular_beamformer_test(unittest.TestCase):
             acoular.config.global_caching = 'readonly'
             b0 = BeamformerBase(freq_data=f, steer=st, r_diag=True, cached=True)
             b1 = BeamformerBase(freq_data=f, steer=st, r_diag=True, cached=True)
-            self.assertEqual(id(b0.result.bf._ac), id(b1.result.bf._ac))
+            np.testing.assert_allclose(b0.result.bf._ac, b1.result.bf._ac)
 
 
 class Test_PowerSpectra(unittest.TestCase):

--- a/tests/test_beamformer_results.py
+++ b/tests/test_beamformer_results.py
@@ -144,8 +144,8 @@ class acoular_beamformer_test(unittest.TestCase):
                 if hasattr(b0, 'beamformer'):  # BeamformerClean, BeamformerDamas, BeamformerDamasplus
                     # do not pass because the .beamformer result is not take from cache
                     continue  # nor recalculated
-                b0.result[:] = 0
-                self.assertFalse(np.any(b0.result))
+                b0.result.bf._ac[:] = 0
+                self.assertFalse(np.any(b0.result.bf._ac))
                 name = testdir / 'reference_data' / f'{b1.__class__.__name__}.npy'
                 actual_data = np.array([b1.synthetic(cf, 1) for cf in cfreqs], dtype=np.float32)
                 ref_data = np.load(name)
@@ -158,24 +158,24 @@ class acoular_beamformer_test(unittest.TestCase):
             acoular.config.global_caching = 'none'
             b0 = BeamformerBase(freq_data=f, steer=st, r_diag=True, cached=True)
             b1 = BeamformerBase(freq_data=f, steer=st, r_diag=True, cached=True)
-            self.assertNotEqual(id(b0.result), id(b1.result))
+            self.assertNotEqual(id(b0.result.bf._ac), id(b1.result.bf._ac))
         with self.subTest("global_caching = 'individual'"):
             acoular.config.global_caching = 'individual'
             b0 = BeamformerBase(freq_data=f, steer=st, r_diag=True, cached=True)
             b1 = BeamformerBase(freq_data=f, steer=st, r_diag=True, cached=True)
-            self.assertEqual(id(b0.result), id(b1.result))
+            self.assertEqual(id(b0.result.bf._ac), id(b1.result.bf._ac))
             b1 = BeamformerBase(freq_data=f, steer=st, r_diag=True, cached=False)
-            self.assertNotEqual(id(b0.result), id(b1.result))
+            self.assertNotEqual(id(b0.result.bf._ac), id(b1.result.bf._ac))
         with self.subTest("global_caching = 'all'"):
             acoular.config.global_caching = 'all'
             b0 = BeamformerBase(freq_data=f, steer=st, r_diag=True, cached=True)
             b1 = BeamformerBase(freq_data=f, steer=st, r_diag=True, cached=False)
-            self.assertEqual(id(b0.result), id(b1.result))
+            self.assertEqual(id(b0.result.bf._ac), id(b1.result.bf._ac))
         with self.subTest("global_caching = 'readonly'"):
             acoular.config.global_caching = 'readonly'
             b0 = BeamformerBase(freq_data=f, steer=st, r_diag=True, cached=True)
             b1 = BeamformerBase(freq_data=f, steer=st, r_diag=True, cached=True)
-            self.assertEqual(id(b0.result), id(b1.result))
+            self.assertEqual(id(b0.result.bf._ac), id(b1.result.bf._ac))
 
 
 class Test_PowerSpectra(unittest.TestCase):


### PR DESCRIPTION
This addresses several issues by reworking some basic mechanics of `BeamformerBase`. In `BeamformerBase` and all derived classes, the result is computed per frequency. As the computations are quite expensive especially for advanced methods, it is inefficient to compute the result for any frequency that is not needed or required in the end. So far, this was controlled by `ind_low` and `ind_high` attributes of the `freq_data` attribute to `BeamformerBase` which lead to problems.  This closes #151 
by introducing a mechanism which computes only for those frequencies that are actually needed when then `result` attribute is queried using the index operator []:

- new private helper class `LazyResultArray` which controls the computation
- `_calc` method replaces 'calc' method
- `BeamformerBase` gets non-public, non-trait attributes to avoid passing them around unnecessarily: `_ac`, `_fr`, `_f` 
- `integrate` method gets new functionality and is now able to integrate _and_ deliver the result as n-th octave spectrum or for just a limited frequency range of interest; this closes #175
- `ext_digest` is no longer necessary, closes #266

While this works for all other `BeamformerBase` derived classes, `BeamformerSODIX` received special treatment:

- `_calc` also computes all frequencies below those actually requested as those results are needed as an initial value for subsequent frequencies
- `sodix_result` is now replaced by `result` as in all other classes
- special versions of `_get_file_cache` and `synthetic` are no longer needed

As a side effect, this pull request leads to a considerable speed-up for the beamformer tests, which need now only 25% of the time to finish.