### PR TITLE
automate conda upload

### DIFF
--- a/.github/actions/setup-conda/action.yml
+++ b/.github/actions/setup-conda/action.yml
@@ -25,4 +25,7 @@ runs:
     - name: Install conda-verify
       shell: bash
       run: conda install conda-verify
+    - name: Install anaconda-client
+      shell: bash
+      run: conda install anaconda-client
 

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -2,7 +2,7 @@ name: Build conda package
 
 on:
     workflow_dispatch:
-      branches: [ '*' ] # allow manual trigger for all branches
+      branches: [ '*' ] # allow manual trigger for all branches (only master will upload to Anaconda Cloud)
   
     
 jobs:

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -1,11 +1,12 @@
 name: Build conda package
 
 on:
-  workflow_dispatch:
-    branches: [ master ] 
+    workflow_dispatch:
+      branches: [ '*' ] # allow manual trigger for all branches
   
+    
 jobs:
-  conda_build_and_install:
+  conda_build_install_upload:
     name: Test conda deployment of package with Python 3.12
     runs-on: ubuntu-latest
     steps:
@@ -20,4 +21,9 @@ jobs:
         with:
           name: conda-package
           path: ./conda_package
+      - name: Upload conda package to Anaconda Cloud
+        if: ${{ github.event_name =='workflow_dispatch' && github.ref == 'refs/heads/master' }}
+        run: |
+          anaconda login --username ${{ secrets.ANACONDA_USERNAME }} --password ${{ secrets.ANACONDA_PASSWORD }}
+          anaconda upload ./conda_package/noarch/*.tar.bz2
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,6 +2,8 @@ name: Label-Bot
 
 on:
   pull_request_target
+  workflow_dispatch:
+    branches: [ "*" ]
 
 jobs:
   labeler:


### PR DESCRIPTION
This change allows to upload the built conda package to anaconda.org

Upload will only take place if a workflow is started manually from the master branch