### PR TITLE
Draft: Blockwise frequency domain processing

### DIFF
--- a/acoular/spectra.py
+++ b/acoular/spectra.py
@@ -130,7 +130,7 @@ class BaseSpectra(HasPrivateTraits):
         return None
 
     # generator that yields the time data blocks for every channel (with optional overlap)
-    def get_source_data(self):
+    def _get_source_data(self):
         bs = self.block_size
         temp = empty((2 * bs, self.numchannels))
         pos = bs
@@ -147,10 +147,7 @@ class BaseSpectra(HasPrivateTraits):
 
 
 class FFTSpectra(BaseSpectra, TimeInOut):
-    """Provides the spectra of multichannel time data.
-
-    Returns Spectra per block over a Generator.
-    """
+    """Provides the Fast Fourier Transform (FFT) of multichannel time data."""
 
     # internal identifier
     digest = Property(depends_on=['source.digest', 'precision', 'block_size', 'window', 'overlap'])
@@ -159,27 +156,33 @@ class FFTSpectra(BaseSpectra, TimeInOut):
     def _get_digest(self):
         return digest(self)
 
-    # generator that yields the fft for every channel
-    def result(self):
-        """Python generator that yields the output block-wise.
+    def result(self, num=1):
+        """Python generator that yields the FFT spectra block-wise.
 
         Parameters
         ----------
         num : integer
-            This parameter defines the size of the blocks to be yielded
-            (i.e. the number of samples per block).
+            This parameter defines the number of the blocks to be yielded
+            per generator call (i.e. the number of FFT spectra given per iteration).
 
         Returns
         -------
-        Samples in blocks of shape (numfreq, :attr:`numchannels`).
+        FFT spectra of shape (num, :attr:`numchannels`, numfreq).
             The last block may be shorter than num.
 
         """
+        numfreq = self.fftfreq().shape[0]
         wind = self.window_(self.block_size)
         weight = sqrt(2) / self.block_size * sqrt(self.block_size / dot(wind, wind)) * wind[:, newaxis]
-        for data in self.get_source_data():
-            ft = fft.rfft(data * weight, None, 0).astype(self.precision)
-            yield ft
+        fftdata = zeros((num, self.numchannels, numfreq), dtype=self.precision)
+        j = 0
+        for i, data in enumerate(self._get_source_data()): # yields one block of time data
+            j = i % num
+            fftdata[j] = fft.rfft(data * weight, None, 0).astype(self.precision).transpose()
+            if j == num - 1:
+                yield fftdata
+        if j < num - 1: # yield remaining fft spectra
+            yield fftdata[: j + 1]
 
 
 class PowerSpectra(BaseSpectra):
@@ -392,7 +395,7 @@ class PowerSpectra(BaseSpectra):
             else:
                 raise ValueError('Calibration data not compatible: %i, %i' % (self.calib.num_mics, t.numchannels))
         # get time data blockwise
-        for data in self.get_source_data():
+        for data in self._get_source_data():
             ft = fft.rfft(data * wind, None, 0).astype(self.precision)
             calcCSM(csm_upper, ft)  # only upper triangular part of matrix is calculated (for speed reasons)
         # create the full csm matrix via transposing and complex conj.

--- a/acoular/tprocess.py
+++ b/acoular/tprocess.py
@@ -1,7 +1,7 @@
 # ------------------------------------------------------------------------------
 # Copyright (c) Acoular Development Team.
 # ------------------------------------------------------------------------------
-"""Implements processing in the time domain.
+"""Implements blockwise processing in the time domain.
 
 .. autosummary::
     :toctree: generated/
@@ -181,6 +181,32 @@ class TimeInOut(SamplesGenerator):
     # internal identifier
     digest = Property(depends_on=['source.digest'])
 
+    def _validate_result_block(self, block, time_data=True, freq_data=False):
+        """Internal helper function to validate the source result block.
+
+        Frequency domain data blocks are of shape (num, numchannels, numfreqs), while time domain
+        data blocks are of shape (num, numchannels). The number of dimensions indicates
+        the type of data.
+        This method handles the validation of a `data` block yielded by the result
+        :meth:`result` method. It checks the dimensions of the block and raises
+        an error if the block has the wrong dimensions / comes from the wrong domain.
+        """
+        if not time_data and block.ndim == 2:  # probably source yields time domain data
+            msg = (f'{self.source.__class__.__name__} yields data with 2 dimensions. '
+                f'{self.__class__.__name__} does not support time domain data to be processed.'
+                )
+            raise NotImplementedError(msg)
+        if not freq_data and block.ndim == 3:  # probably source yields frequency domain data
+            msg = (f'{self.source.__class__.__name__} yields data with 3 dimensions. '
+                f'{self.__class__.__name__} does not support frequency domain data to be processed.'
+                )
+            raise NotImplementedError(msg)
+        expected_dims = [2,3]
+        if block.ndim not in expected_dims:
+            msg = (f'{self.source.__class__.__name__} yields data with {block.ndim} dimensions, '
+                f'but {self.__class__.__name__} expects on of {expected_dims}.')
+            raise ValueError(msg)
+
     @cached_property
     def _get_digest(self):
         return digest(self)
@@ -292,6 +318,8 @@ class MaskedTimeInOut(TimeInOut):
             i = 0
             fblock = True
             for block in self.source.result(num):
+                if i == 0: # validate first block
+                    self._validate_result_block(block, time_data=True, freq_data=False)
                 bs = block.shape[0]
                 i += bs
                 if fblock and i >= start:  # first block in the chosen interval
@@ -365,7 +393,9 @@ class ChannelMixer(TimeInOut):
         else:
             weights = 1
 
-        for block in self.source.result(num):
+        for i, block in enumerate(self.source.result(num)):
+            if i == 0:
+                self._validate_result_block(block, time_data=True, freq_data=True)
             yield sum(weights * block, 1, keepdims=True)
 
 
@@ -1415,7 +1445,7 @@ class TimePower(TimeInOut):
 
         """
         for temp in self.source.result(num):
-            yield temp * temp
+            yield temp * temp.conjugate()
 
 
 class TimeAverage(TimeInOut):
@@ -1467,10 +1497,15 @@ class TimeAverage(TimeInOut):
         """
         nav = self.naverage
         for temp in self.source.result(num * nav):
-            ns, nc = temp.shape
+            ns, nc = temp.shape[:2]
             nso = int(ns / nav)
+            if temp.ndim ==3:
+                nf = temp.shape[2]
+                oshape = (nso, -1, nc, nf)
+            else:
+                oshape = (nso, -1, nc)
             if nso > 0:
-                yield temp[: nso * nav].reshape((nso, -1, nc)).mean(axis=1)
+                yield temp[: nso * nav].reshape(oshape).mean(axis=1)
 
 
 class TimeCumAverage(TimeInOut):

--- a/examples/io_and_signal_processing_examples/example_spectrogram.py
+++ b/examples/io_and_signal_processing_examples/example_spectrogram.py
@@ -1,0 +1,63 @@
+#%%
+#Imports
+
+import acoular as ac
+import numpy as np
+
+#%%
+# We define two sine wave signals with different frequencies (1000 Hz and 4000 Hz) and a noise signal.
+# Then, the signals are calculated and added together.
+sample_freq = 44100
+t_in_s = 10.0
+numsamples = int(sample_freq * t_in_s)
+
+sine1 = ac.SineGenerator(sample_freq=sample_freq, numsamples=numsamples, freq=2000, amplitude=1.0)
+sine2 = ac.SineGenerator(sample_freq=sample_freq, numsamples=numsamples, freq=8000, amplitude=0.5)
+noise = ac.WNoiseGenerator(sample_freq=sample_freq, numsamples=numsamples, rms=1.0)
+mixed_signal = sine1.signal() + sine2.signal() + noise.signal()
+
+
+#%%
+# The mixed signal is then used to create a TimeSamples object.
+
+ts = ac.TimeSamples(data = mixed_signal[:,np.newaxis], sample_freq = sample_freq)
+print(ts.numsamples, ts.numchannels)
+
+# %%
+# Next we want to process the FFT spectra of the signal blockwise.
+# To do so, we use the :class:`acoular.spectra.FFTSpectra` class, 
+# which calculates the FFT spectra of the signal blockwise.
+
+fft = ac.FFTSpectra(source = ts, block_size = 512, window = 'Hanning',
+                    overlap = '50%')
+tp = ac.TimePower(source = fft) # results in the power spectrum
+tavg = ac.TimeAverage(source = tp) # results in the time averaged power spectrum
+
+# %%
+# Plot the spectrogram of the signal for different number of averages.
+
+import matplotlib.pyplot as plt
+
+plt.figure()
+for navg in [1, 10, 100]:
+    tavg.naverage = navg
+    spectrum = next(tavg.result(1))
+    Lm = ac.L_p(spectrum[0][0])
+    freqs = fft.fftfreq()
+    plt.plot(freqs, Lm, label=f"navg = {navg}")
+plt.xlabel('Frequency / Hz')
+plt.ylabel('Power Spectrum / dB')
+plt.grid()
+plt.legend()
+plt.semilogx()
+
+# plot the power spectrogram
+plt.figure()
+full_result = ac.tools.helpers.return_result(tp, num=1)[:,0,:]
+plt.imshow(ac.L_p(full_result.real).T, origin='lower', aspect='auto', extent=(0, t_in_s, 0, sample_freq/2))
+plt.xlabel('Time / s')
+plt.ylabel('Frequency / Hz')
+plt.colorbar(label='Power Spectrum / dB')
+plt.show()
+
+# %%


### PR DESCRIPTION
I would like to discuss a draft that extends the blockwise processing of frequency domain data.

# Current State

The class `FFTSpectra` transforms time data coming from a `SamplesGenerator` derived class into the frequency domain. This is done **blockwise** with the `result` method.

The class has one bug: it breaks the philosophy of the result generator method since no `num` argument currently exists. 

# Extension

`FFTSpectra.result` now has a `num` argument determining the number of spectra yielded. In contrast to `TimeInOut` derived classes, the output is of shape `(num, numchannels, numfrequencies)` instead of `(num, numchannels)`

Theoretically, since `FFTSpectra` is derived from `TimeInOut`, it can be used as a source for existing classes such as `TimeAverage` or `TimePower` to process frequency domain data. Although this did not work out of the box, extending the functionality was easy for the two classes. However, there will always be some classes that cannot handle sources yielding frequency domain data, or it is at least cumbersome to implement processing in both domains. 

I want to discuss two different solutions, both with pros and cons. (Maybe there are more solutions I have not considered so far.)

## Draft 1 – no explicit freq domain definition

This would mean that `TimeInOut` and `SamplesGenerator` derived classes are not limited to a certain domain. It depends on the class if time data and/or frequency domain data can be handled.

I introduced a `_validate_result_block` method, which can be used to determine the source data domain based on the given block shape. If the class processing the data can't handle the domain, an error is raised. 

 Alternatively, one may consider introducing a (private?) `domain` trait that is delegated from the source and validated by the subsequent class. This would make it possible to detect invalid pipelines before processing starts.

**Pros:**
*  No redundant code 

**Cons**:
* The purpose of a class (freq and/or time domain) can be complicated to recognize. (Requires a thorough documentation)


## Draft 2 - explicit freq domain classes

A clear but also extensive addition would be to introduce a `fprocess.py` module by analogy to the `tprocess.py` module. This module would have a `FreqGenerator` and a ` FreqInOut` class. E.g: 

```python


class FreqGenerator(HasPrivateTraits):
    """Base class for any generating signal processing block in frequency domain."""

    #: Sampling frequency of the signal, defaults to 1.0
    sample_freq = Float(1.0, desc='sampling frequency')

    #: Number of channels
    numchannels = CLong

    #: Number of samples
    numsamples = CLong

    #: Number of samples
    numfreq = CLong

    [...]

class FreqInOut(FreqGenerator):
    """Base class for any frequency domain signal processing block."""

    #: Data source; :class:`~acoular.sources.FreqGenerator` or derived object.
    source = Trait(FreqGenerator)


class FreqPower(FreqInOut):
    """Calculates time-depended power of the signal."""

    #: Data source; :class:`~acoular.fprocess.FreqInOut` or derived object.
    source = Trait(FreqInOut)

    def result(self, num):
        """Python generator that yields the output blockwise.

       Returns
        -------
        Squared output of source.
            Yields blocks of shape (num, numchannels, numfreq).
            The last block may be shorter than num.

        """
        for temp in self.source.result(num):
            yield temp * temp.conjugate()
```

**Pros:**
*  very clear interface
* would enable potentially useful subclasses (`FreqSamples` -> read frequency data from .h5 files)

**Cons**:
* redundant (or even doubled code)
* higher maintenance effort


---

Thoughts?  @gherold, @esarradj, @artpelling, @FrankK20 


