### PR TITLE
More platform compatipility

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -37,6 +37,9 @@ authors:
   - given-names: "Jakob"
     family-names: "Tschavoll"
     affiliation: "Audio Communication Group, TU Berlin"
+  - given-name: "Jan"
+    family-name: "Ostendorf"
+    affiliation: "Department of Engineering Acoustics, TU Berlin"
 identifiers:
   - description: "acoular: all versions"
     type: "doi"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,6 @@ dependencies = ["ruff==0.4.1"]
 config-path = [".ruff.toml"]
 
 [tool.hatch.envs.docs]
-platforms = ["linux"]
 python = "3.12"
 dependencies = [
     "acoular[docs]"


### PR DESCRIPTION
Building docs with hatch is now no longer bound to Linux platforms.