### PR TITLE
add edited labeler to types

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -3,7 +3,7 @@ name: GitHub
 on:
   pull_request:
     branches: master
-    types: [labeled, unlabeled, opened, synchronize, reopened]
+    types: [labeled, unlabeled, opened, synchronize, reopened, edited]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Hopefully fixes labeler CI. (see https://github.com/yogevbd/enforce-label-action/issues/27). Current PR is stuck and requires making a dummy commit, even after label assignment. (see PR #316 )