### PR TITLE
Fix deprecation

### DIFF
--- a/acoular/base.py
+++ b/acoular/base.py
@@ -294,7 +294,7 @@ class TimeInOut(TimeOut):
     """Deprecated alias for :class:`~acoular.base.TimeOut`.
 
     .. deprecated:: 24.10
-        Using :class:`~acoular.base.TimeInOut` is deprecated and will be removed in Acoular 25.01.
+        Using :class:`~acoular.base.TimeInOut` is deprecated and will be removed in Acoular 25.07.
         Use :class:`~acoular.base.TimeOut` instead.
     """
 
@@ -306,7 +306,7 @@ class TimeInOut(TimeOut):
         import warnings
 
         warnings.warn(
-            'TimeInOut is deprecated and will be removed in Acoular 25.01. Use TimeOut instead.',
+            'TimeInOut is deprecated and will be removed in Acoular 25.07. Use TimeOut instead.',
             DeprecationWarning,
             stacklevel=2,
         )

--- a/acoular/fbeamform.py
+++ b/acoular/fbeamform.py
@@ -659,7 +659,7 @@ class BeamformerBase(HasPrivateTraits):
             each grid point .
             Note that the frequency resolution and therefore the bandwidth
             represented by a single frequency line depends on
-            the :attr:`sampling frequency<acoular.tprocess.SamplesGenerator.sample_freq>` and
+            the :attr:`sampling frequency<acoular.base.SamplesGenerator.sample_freq>` and
             used :attr:`FFT block size<acoular.spectra.PowerSpectra.block_size>`.
 
         """
@@ -951,7 +951,7 @@ class BeamformerEig(BeamformerBase):
     """
 
     #: Number of component to calculate:
-    #: 0 (smallest) ... :attr:`~acoular.tprocess.SamplesGenerator.numchannels`-1;
+    #: 0 (smallest) ... :attr:`~acoular.base.SamplesGenerator.numchannels`-1;
     #: defaults to -1, i.e. numchannels-1
     n = Int(-1, desc='No. of eigenvalue')
 

--- a/acoular/fbeamform.py
+++ b/acoular/fbeamform.py
@@ -1399,7 +1399,8 @@ class BeamformerDamas(BeamformerBase):
 
     def _set_beamformer(self, beamformer):
         msg = (
-            "Deprecated use of 'beamformer' trait. Please set :attr:`freq_data`, :attr:`steer`, :attr:`r_diag` directly."
+            f"Deprecated use of 'beamformer' trait in class {self.__class__.__name__}. "
+            'Please set :attr:`freq_data`, :attr:`steer`, :attr:`r_diag` directly. '
             "Using the 'beamformer' trait will be removed in version 25.07."
         )
         warn(
@@ -1613,7 +1614,8 @@ class BeamformerOrth(BeamformerBase):
 
     def _set_beamformer(self, beamformer):
         msg = (
-            "Deprecated use of 'beamformer' trait. Please set :attr:`freq_data`, :attr:`steer`, :attr:`r_diag` directly."
+            f"Deprecated use of 'beamformer' trait in class {self.__class__.__name__}. "
+            'Please set :attr:`freq_data`, :attr:`steer`, :attr:`r_diag` directly. '
             "Using the 'beamformer' trait will be removed in version 25.07."
         )
         warn(
@@ -1806,7 +1808,8 @@ class BeamformerClean(BeamformerBase):
 
     def _set_beamformer(self, beamformer):
         msg = (
-            "Deprecated use of 'beamformer' trait. Please set :attr:`freq_data`, :attr:`steer`, :attr:`r_diag` directly."
+            f"Deprecated use of 'beamformer' trait in class {self.__class__.__name__}. "
+            'Please set :attr:`freq_data`, :attr:`steer`, :attr:`r_diag` directly. '
             "Using the 'beamformer' trait will be removed in version 25.07."
         )
         warn(

--- a/acoular/fbeamform.py
+++ b/acoular/fbeamform.py
@@ -1370,8 +1370,11 @@ class BeamformerDamas(BeamformerBase):
 
     #: (only for backward compatibility) :class:`BeamformerBase` object
     #: if set, provides :attr:`freq_data`, :attr:`steer`, :attr:`r_diag`
-    #: if not set, these have to be set explicitly
-    beamformer = Trait(BeamformerBase)
+    #: if not set, these have to be set explicitly.
+    beamformer = Property()
+
+    # private storage of beamformer instance
+    _beamformer = Trait(BeamformerBase)
 
     #: The floating-number-precision of the PSFs. Default is 64 bit.
     psf_precision = Trait('float64', 'float32', desc='precision of PSF')
@@ -1391,11 +1394,26 @@ class BeamformerDamas(BeamformerBase):
         depends_on=BEAMFORMER_BASE_DIGEST_DEPENDENCIES + ['n_iter', 'damp', 'psf_precision'],
     )
 
+    def _get_beamformer(self):
+        return self._beamformer
+
+    def _set_beamformer(self, beamformer):
+        msg = (
+            "Deprecated use of 'beamformer' trait. Please set :attr:`freq_data`, :attr:`steer`, :attr:`r_diag` directly."
+            "Using the 'beamformer' trait will be removed in version 25.07."
+        )
+        warn(
+            msg,
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self._beamformer = beamformer
+
     @cached_property
     def _get_digest(self):
         return digest(self)
 
-    @on_trait_change('beamformer.digest')
+    @on_trait_change('_beamformer.digest')
     def delegate_beamformer_traits(self):
         self.freq_data = self.beamformer.freq_data
         self.r_diag = self.beamformer.r_diag
@@ -1569,8 +1587,11 @@ class BeamformerOrth(BeamformerBase):
 
     #: (only for backward compatibility) :class:`BeamformerEig` object
     #: if set, provides :attr:`freq_data`, :attr:`steer`, :attr:`r_diag`
-    #: if not set, these have to be set explicitly
-    beamformer = Trait(BeamformerEig)
+    #: if not set, these have to be set explicitly.
+    beamformer = Property()
+
+    # private storage of beamformer instance
+    _beamformer = Trait(BeamformerEig)
 
     #: List of components to consider, use this to directly set the eigenvalues
     #: used in the beamformer. Alternatively, set :attr:`n`.
@@ -1587,11 +1608,26 @@ class BeamformerOrth(BeamformerBase):
         depends_on=BEAMFORMER_BASE_DIGEST_DEPENDENCIES + ['eva_list'],
     )
 
+    def _get_beamformer(self):
+        return self._beamformer
+
+    def _set_beamformer(self, beamformer):
+        msg = (
+            "Deprecated use of 'beamformer' trait. Please set :attr:`freq_data`, :attr:`steer`, :attr:`r_diag` directly."
+            "Using the 'beamformer' trait will be removed in version 25.07."
+        )
+        warn(
+            msg,
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self._beamformer = beamformer
+
     @cached_property
     def _get_digest(self):
         return digest(self)
 
-    @on_trait_change('beamformer.digest')
+    @on_trait_change('_beamformer.digest')
     def delegate_beamformer_traits(self):
         self.freq_data = self.beamformer.freq_data
         self.r_diag = self.beamformer.r_diag
@@ -1737,8 +1773,11 @@ class BeamformerClean(BeamformerBase):
 
     #: (only for backward compatibility) :class:`BeamformerBase` object
     #: if set, provides :attr:`freq_data`, :attr:`steer`, :attr:`r_diag`
-    #: if not set, these have to be set explicitly
-    beamformer = Trait(BeamformerBase)
+    #: if not set, these have to be set explicitly.
+    beamformer = Property()
+
+    # private storage of beamformer instance
+    _beamformer = Trait(BeamformerBase)
 
     #: The floating-number-precision of the PSFs. Default is 64 bit.
     psf_precision = Trait('float64', 'float32', desc='precision of PSF.')
@@ -1762,7 +1801,22 @@ class BeamformerClean(BeamformerBase):
     def _get_digest(self):
         return digest(self)
 
-    @on_trait_change('beamformer.digest')
+    def _get_beamformer(self):
+        return self._beamformer
+
+    def _set_beamformer(self, beamformer):
+        msg = (
+            "Deprecated use of 'beamformer' trait. Please set :attr:`freq_data`, :attr:`steer`, :attr:`r_diag` directly."
+            "Using the 'beamformer' trait will be removed in version 25.07."
+        )
+        warn(
+            msg,
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self._beamformer = beamformer
+
+    @on_trait_change('_beamformer.digest')
     def delegate_beamformer_traits(self):
         self.freq_data = self.beamformer.freq_data
         self.r_diag = self.beamformer.r_diag

--- a/acoular/fprocess.py
+++ b/acoular/fprocess.py
@@ -362,7 +362,7 @@ class FFTSpectra(RFFT):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         warn(
-            'Using FFTSpectra is deprecated and will be removed in Acoular version 25.01. Use class RFFT instead.',
+            'Using FFTSpectra is deprecated and will be removed in Acoular version 25.07. Use class RFFT instead.',
             DeprecationWarning,
             stacklevel=2,
         )

--- a/acoular/fprocess.py
+++ b/acoular/fprocess.py
@@ -356,7 +356,7 @@ class FFTSpectra(RFFT):
 
     .. deprecated:: 24.10
         Using :class:`~acoular.fprocess.FFTSpectra` is deprecated and will be removed in Acoular
-        version 25.01. Use :class:`~acoular.fprocess.RFFT` instead.
+        version 25.07. Use :class:`~acoular.fprocess.RFFT` instead.
     """
 
     def __init__(self, *args, **kwargs):

--- a/acoular/process.py
+++ b/acoular/process.py
@@ -435,13 +435,13 @@ class TimeAverage(Average):
 
     .. deprecated:: 24.10
         Using :class:`~acoular.process.TimeAverage` is deprecated and will be removed in Acoular
-        version 25.01. Use :class:`~acoular.process.Average` instead.
+        version 25.07. Use :class:`~acoular.process.Average` instead.
     """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         warn(
-            'Using TimeAverage is deprecated and will be removed in Acoular version 25.01. Use Average instead.',
+            'Using TimeAverage is deprecated and will be removed in Acoular version 25.07. Use Average instead.',
             DeprecationWarning,
             stacklevel=2,
         )
@@ -452,13 +452,13 @@ class TimeCache(Cache):
 
     .. deprecated:: 24.10
         Using :class:`~acoular.process.TimeCache` is deprecated and will be removed in Acoular
-        version 25.01. Use :class:`~acoular.process.Cache` instead.
+        version 25.07. Use :class:`~acoular.process.Cache` instead.
     """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         warn(
-            'Using TimeCache is deprecated and will be removed in Acoular version 25.01. Use Cache instead.',
+            'Using TimeCache is deprecated and will be removed in Acoular version 25.07. Use Cache instead.',
             DeprecationWarning,
             stacklevel=2,
         )

--- a/acoular/spectra.py
+++ b/acoular/spectra.py
@@ -52,13 +52,13 @@ from traits.api import (
     property_depends_on,
 )
 
+from .base import SamplesGenerator
 from .calib import Calib
 from .configuration import config
 from .fastFuncs import calcCSM
 from .h5cache import H5cache
 from .h5files import H5CacheFileBase
 from .internal import digest
-from .tprocess import SamplesGenerator
 
 
 class BaseSpectra(HasPrivateTraits):

--- a/acoular/spectra.py
+++ b/acoular/spectra.py
@@ -103,8 +103,8 @@ class BaseSpectra(HasPrivateTraits):
         desc='number of samples per FFT block',
     )
 
-    #: The floating-number-precision of entries of csm, eigenvalues and
-    #: eigenvectors, corresponding to numpy dtypes. Default is 64 bit.
+    #: The floating-number-precision of the resulting spectra, corresponding to numpy dtypes.
+    #: Default is 'complex128'.
     precision = Trait('complex128', 'complex64', desc='precision of the fft')
 
     # internal identifier
@@ -128,7 +128,7 @@ class BaseSpectra(HasPrivateTraits):
         return None
 
     # generator that yields the time data blocks for every channel (with optional overlap)
-    def get_source_data(self):
+    def _get_source_data(self):
         bs = self.block_size
         temp = empty((2 * bs, self.numchannels))
         pos = bs
@@ -168,7 +168,7 @@ class PowerSpectra(BaseSpectra):
     #: Data source; :class:`~acoular.sources.SamplesGenerator` or derived object.
     source = Property(_source, desc='time data object')
 
-    #: The :class:`~acoular.tprocess.SamplesGenerator` object that provides the data.
+    #: The :class:`~acoular.base.SamplesGenerator` object that provides the data.
     time_data = Property(
         _source,
         desc='deprecated attribute holding the time data object. Use PowerSpectra.source instead!',
@@ -373,7 +373,7 @@ class PowerSpectra(BaseSpectra):
             else:
                 raise ValueError('Calibration data not compatible: %i, %i' % (self.calib.num_mics, t.numchannels))
         # get time data blockwise
-        for data in self.get_source_data():
+        for data in self._get_source_data():
             ft = fft.rfft(data * wind, None, 0).astype(self.precision)
             calcCSM(csm_upper, ft)  # only upper triangular part of matrix is calculated (for speed reasons)
         # create the full csm matrix via transposing and complex conj.
@@ -575,7 +575,7 @@ def synthetic(data, freqs, f, num=3):
         each grid point (the sum of all values that are contained in the band).
         Note that the frequency resolution and therefore the bandwidth
         represented by a single frequency line depends on
-        the :attr:`sampling frequency<acoular.tprocess.SamplesGenerator.sample_freq>`
+        the :attr:`sampling frequency<acoular.base.SamplesGenerator.sample_freq>`
         and used :attr:`FFT block size<acoular.spectra.PowerSpectra.block_size>`.
 
     """

--- a/acoular/spectra.py
+++ b/acoular/spectra.py
@@ -7,7 +7,6 @@
     :toctree: generated/
 
     BaseSpectra
-    FFTSpectra
     PowerSpectra
     synthetic
     PowerSpectraImport
@@ -33,7 +32,6 @@ from numpy import (
     ones,
     real,
     searchsorted,
-    sqrt,
     sum,
     zeros,
     zeros_like,
@@ -60,7 +58,7 @@ from .fastFuncs import calcCSM
 from .h5cache import H5cache
 from .h5files import H5CacheFileBase
 from .internal import digest
-from .tprocess import SamplesGenerator, TimeInOut
+from .tprocess import SamplesGenerator
 
 
 class BaseSpectra(HasPrivateTraits):

--- a/acoular/tools/helpers.py
+++ b/acoular/tools/helpers.py
@@ -24,13 +24,13 @@ from acoular.spectra import synthetic
 
 def return_result(source, nmax=-1, num=128):
     """Collects the output from a
-    :meth:`SamplesGenerator.result()<acoular.tprocess.SamplesGenerator.result>`
+    :meth:`SamplesGenerator.result()<acoular.base.SamplesGenerator.result>`
     generator and returns an assembled array with all the data.
 
     Parameters
     ----------
     source: SamplesGenerator or derived object.
-        This is the  :class:`SamplesGenerator<acoular.tprocess.SamplesGenerator>` data source.
+        This is the  :class:`SamplesGenerator<acoular.base.SamplesGenerator>` data source.
     nmax: integer
         With this parameter, a maximum number of output samples can be set
         (first dimension of array). If set to -1 (default), samples are

--- a/acoular/tprocess.py
+++ b/acoular/tprocess.py
@@ -2066,13 +2066,13 @@ class MaskedTimeInOut(MaskedTimeOut):
 
     .. deprecated:: 24.10
         Using :class:`~acoular.tprocess.MaskedTimeInOut` is deprecated and will be removed in Acoular
-        version 25.01. Use :class:`~acoular.tprocess.MaskedTimeOut` instead.
+        version 25.07. Use :class:`~acoular.tprocess.MaskedTimeOut` instead.
     """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         warn(
-            'Using MaskedTimeInOut is deprecated and will be removed in Acoular version 25.01. Use class MaskedTimeOut instead.',
+            'Using MaskedTimeInOut is deprecated and will be removed in Acoular version 25.07. Use class MaskedTimeOut instead.',
             DeprecationWarning,
             stacklevel=2,
         )

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -1,15 +1,40 @@
 # ------------------------------------------------------------------------------
 # Copyright (c) Acoular Development Team.
 # ------------------------------------------------------------------------------
-"""Implements testing of frequency beamformers."""
+"""Tests if all Acoular classes can be instatiated and if important traits can be set without errors."""
 
+import importlib
+import inspect
+import pkgutil
+import tempfile
 import warnings
 
-import acoular as ac
 import pytest
-from traits.api import Bool, Enum, Float, HasTraits, Int, Range, TraitEnum
+from traits.api import Bool, Enum, Float, Int, Range, TraitEnum
 
-all_classes = dir(ac)
+
+def get_all_classes():
+    classes = []
+    package = importlib.import_module('acoular')
+    for module_info in pkgutil.walk_packages(package.__path__, package.__name__ + '.'):
+        module = importlib.import_module(module_info.name)
+        for _, obj in inspect.getmembers(module, inspect.isclass):
+            if obj.__module__ == module_info.name:  # ensure class is defined in the current module
+                classes.append(obj)
+    return classes
+
+
+def create_instance(acoular_cls):
+    if acoular_cls.__name__ in ['H5CacheFileH5py', 'H5CacheFileTables', 'H5FileH5py', 'H5FileTables']:
+        return acoular_cls(tempfile.mkstemp()[1] + '.h5', 'w')
+    if acoular_cls.__name__ in ['LockedGenerator', 'LazyBfResult']:
+        return acoular_cls(None)
+    if acoular_cls.__name__ == 'Polygon':
+        return acoular_cls([0], [1])
+    return acoular_cls()
+
+
+all_classes = get_all_classes()
 
 
 @pytest.mark.parametrize('acoular_cls', all_classes)
@@ -17,10 +42,7 @@ def test_instancing(acoular_cls):
     """test that all Acoular classes can be instatiated."""
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', category=DeprecationWarning)
-        # iterate over all Acoular definitions labels
-        j = getattr(ac, acoular_cls)  # class, function or variable
-        if isinstance(j, type):  # is this a class ?
-            j()  # this is an instance of the class
+        create_instance(acoular_cls)
 
 
 @pytest.mark.parametrize('acoular_cls', all_classes)
@@ -28,16 +50,13 @@ def test_set_traits(acoular_cls):
     """test that important traits can be set."""
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', category=DeprecationWarning)
-        # iterate over all Acoular definitions labels
-        j = getattr(ac, acoular_cls)  # class, function or variable
-        # HasTraits derived class ?
-        if isinstance(j, type) and issubclass(j, HasTraits) and ('digest' in j.class_traits()):
-            do = j.class_traits()['digest'].depends_on
+        if hasattr(acoular_cls, 'class_traits') and 'digest' in acoular_cls.class_traits():
+            do = acoular_cls.class_traits()['digest'].depends_on
             if do:
-                obj = j()
+                obj = create_instance(acoular_cls)
                 for k in do:
-                    if k in j.class_trait_names():
-                        tr = j.class_traits()[k]
+                    if k in acoular_cls.class_trait_names():
+                        tr = acoular_cls.class_traits()[k]
                         # handling different Trait types
                         # TODO: use hypothesis based setattr
                         if tr.is_trait_type(Int):

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -3,56 +3,53 @@
 # ------------------------------------------------------------------------------
 """Implements testing of frequency beamformers."""
 
-import unittest
+import warnings
 
 import acoular as ac
+import pytest
 from traits.api import Bool, Enum, Float, HasTraits, Int, Range, TraitEnum
 
+all_classes = dir(ac)
 
-class Test_Instancing(unittest.TestCase):
-    """Test that ensures that digest of Acoular classes changes correctly on
-    changes of CArray and List attributes.
-    """
 
-    def test_instancing(self):
-        """test that all Acoular classes can be instatiated."""
+@pytest.mark.parametrize('acoular_cls', all_classes)
+def test_instancing(acoular_cls):
+    """test that all Acoular classes can be instatiated."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', category=DeprecationWarning)
         # iterate over all Acoular definitions labels
-        for i in dir(ac):
-            with self.subTest(i):
-                j = getattr(ac, i)  # class, function or variable
-                if isinstance(j, type):  # is this a class ?
-                    j()  # this is an instance of the class
+        j = getattr(ac, acoular_cls)  # class, function or variable
+        if isinstance(j, type):  # is this a class ?
+            j()  # this is an instance of the class
 
-    def test_set_traits(self):
-        """test that important traits can be set."""
+
+@pytest.mark.parametrize('acoular_cls', all_classes)
+def test_set_traits(acoular_cls):
+    """test that important traits can be set."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', category=DeprecationWarning)
         # iterate over all Acoular definitions labels
-        for i in dir(ac):
-            j = getattr(ac, i)  # class, function or variable
-            # HasTraits derived class ?
-            if isinstance(j, type) and issubclass(j, HasTraits) and ('digest' in j.class_traits()):
-                do = j.class_traits()['digest'].depends_on
-                if do:
-                    obj = j()
-                    for k in do:
-                        with self.subTest(i + '.' + k):
-                            if k in j.class_trait_names():
-                                tr = j.class_traits()[k]
-                                # handling different Trait types
-                                # TODO: use hypothesis based setattr
-                                if tr.is_trait_type(Int):
-                                    setattr(obj, k, 1)
-                                elif tr.is_trait_type(Float):
-                                    setattr(obj, k, 0.1)
-                                elif tr.is_trait_type(Bool):
-                                    setattr(obj, k, False)
-                                elif tr.is_trait_type(Range):
-                                    low = tr.handler._low
-                                    high = tr.handler._high
-                                    setattr(obj, k, (high + low) / 2)
-                                elif tr.is_trait_type(TraitEnum) or tr.is_trait_type(Enum):
-                                    v = tr.handler.values
-                                    setattr(obj, k, v[len(v) // 2])
-
-
-if __name__ == '__main__':
-    unittest.main()
+        j = getattr(ac, acoular_cls)  # class, function or variable
+        # HasTraits derived class ?
+        if isinstance(j, type) and issubclass(j, HasTraits) and ('digest' in j.class_traits()):
+            do = j.class_traits()['digest'].depends_on
+            if do:
+                obj = j()
+                for k in do:
+                    if k in j.class_trait_names():
+                        tr = j.class_traits()[k]
+                        # handling different Trait types
+                        # TODO: use hypothesis based setattr
+                        if tr.is_trait_type(Int):
+                            setattr(obj, k, 1)
+                        elif tr.is_trait_type(Float):
+                            setattr(obj, k, 0.1)
+                        elif tr.is_trait_type(Bool):
+                            setattr(obj, k, False)
+                        elif tr.is_trait_type(Range):
+                            low = tr.handler._low
+                            high = tr.handler._high
+                            setattr(obj, k, (high + low) / 2)
+                        elif tr.is_trait_type(TraitEnum) or tr.is_trait_type(Enum):
+                            v = tr.handler.values
+                            setattr(obj, k, v[len(v) // 2])


### PR DESCRIPTION
again closes: #309 

* Fix newly introduced deprecation warnings in tests
* use pytest instead of unittests in `test_classes.py`
* actively deprecate the use of the `beamformer` trait
* loose deprecation policy (newly introduced DeprecationWarnings will take effect three releases after introduction)