### PR TITLE
Numpy 2.0

### DIFF
--- a/acoular/environments.py
+++ b/acoular/environments.py
@@ -43,9 +43,9 @@ from numpy import (
     vstack,
     zeros_like,
 )
-from numpy.linalg.linalg import norm
 from scipy.integrate import ode
 from scipy.interpolate import LinearNDInterpolator
+from scipy.linalg import norm
 from scipy.spatial import ConvexHull
 from traits.api import CArray, Dict, Float, HasPrivateTraits, Int, Property, Trait, cached_property
 

--- a/acoular/fbeamform.py
+++ b/acoular/fbeamform.py
@@ -60,7 +60,6 @@ from numpy import (
     integer,
     invert,
     isscalar,
-    linalg,
     log10,
     ndarray,
     newaxis,
@@ -82,9 +81,8 @@ from numpy import (
     zeros,
     zeros_like,
 )
-from numpy.linalg import norm
 from packaging.version import parse
-from scipy.linalg import eigh, eigvals, fractional_matrix_power, inv
+from scipy.linalg import eigh, eigvals, fractional_matrix_power, inv, norm
 from scipy.optimize import fmin_l_bfgs_b, linprog, nnls, shgo
 from sklearn.linear_model import LassoLars, LassoLarsCV, LassoLarsIC, LinearRegression, OrthogonalMatchingPursuitCV
 from traits.api import (
@@ -938,7 +936,7 @@ class BeamformerCapon(BeamformerBase):
         normfactor = self.sig_loss_norm() * nMics**2
         param_steer_type, steer_vector = self._beamformer_params()
         for i in ind:
-            csm = array(linalg.inv(array(self.freq_data.csm[i], dtype='complex128')), order='C')
+            csm = array(inv(array(self.freq_data.csm[i], dtype='complex128')), order='C')
             beamformerOutput = beamformerFreq(param_steer_type, self.r_diag, normfactor, steer_vector(f[i]), csm)[0]
             self._ac[i] = 1.0 / beamformerOutput
             self._fr[i] = 1

--- a/acoular/grids.py
+++ b/acoular/grids.py
@@ -806,7 +806,7 @@ class LineGrid(Grid):
     def _get_gpos(self):
         dist = self.length / (self.numpoints - 1)
         loc = array(self.loc, dtype=float).reshape((3, 1))
-        direc_n = self.direction / norm(self.direction)
+        direc_n = array(self.direction) / norm(self.direction)
         pos = zeros((self.numpoints, 3))
         for s in range(self.numpoints):
             pos[s] = loc.T + direc_n * dist * s

--- a/acoular/grids.py
+++ b/acoular/grids.py
@@ -51,7 +51,7 @@ from numpy import (
     where,
     zeros,
 )
-from numpy.linalg import norm
+from scipy.linalg import norm
 
 # from matplotlib.path import Path
 from scipy.spatial import Delaunay

--- a/acoular/sources.py
+++ b/acoular/sources.py
@@ -51,7 +51,7 @@ from numpy import (
 )
 from numpy import min as npmin
 from numpy.fft import fft, ifft
-from numpy.linalg import norm
+from scipy.linalg import norm
 from scipy.special import sph_harm, spherical_jn, spherical_yn
 from traits.api import (
     Any,

--- a/acoular/tbeamform.py
+++ b/acoular/tbeamform.py
@@ -43,7 +43,7 @@ from numpy import (
     where,
     zeros,
 )
-from numpy.linalg import norm
+from scipy.linalg import norm
 from traits.api import Bool, CArray, Delegate, Enum, Float, Instance, Int, List, Property, Range, Trait, cached_property
 from traits.trait_errors import TraitError
 

--- a/acoular/tprocess.py
+++ b/acoular/tprocess.py
@@ -75,9 +75,9 @@ from numpy import (
     unique,
     zeros,
 )
-from numpy.linalg import norm
 from scipy.fft import irfft, rfft
 from scipy.interpolate import CloughTocher2DInterpolator, CubicSpline, LinearNDInterpolator, Rbf, splev, splrep
+from scipy.linalg import norm
 from scipy.signal import bilinear, butter, sosfilt, sosfiltfilt, tf2sos
 from scipy.spatial import Delaunay
 from traits.api import (

--- a/docs/source/news/index.rst
+++ b/docs/source/news/index.rst
@@ -37,6 +37,9 @@ Upcoming Release
             * allows more files to be checked, including the .rst files in the documentation
             * adds a cron job that runs daily
         * sets final version for several deprecated traits. (Will be removed in version 25.01)
+        * use scipy.linalg consistently over numpy.linalg
+        * drops support for Python 3.8 and 3.9
+        * enable Numpy version > 2.0
 
 24.07
 ------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "numba",
-    "numpy<2.0",
+    "numpy",
     "scipy>=1.1.0",
     "scikit-learn",
     "tables>=3.4.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,13 +28,11 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "numpy<2.0; python_version == '3.9'",
-    "numpy; python_version == '3.8'",
-    "numpy; python_version >= '3.10'",
+    "numpy",
     "numba",
     "scipy>=1.1.0",
     "scikit-learn",
-    "tables>=3.4.4",
+    "tables",
     "traits>=6.0",
 ]
 maintainers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,12 +28,13 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "numpy<2.0; python_version in ['3.8', '3.9']",
+    "numpy<2.0; python_version == '3.9'",
+    "numpy; python_version == '3.8'",
     "numpy; python_version >= '3.10'",
     "numba",
     "scipy>=1.1.0",
     "scikit-learn",
-    "tables>=3.10",
+    "tables>=3.4.4",
     "traits>=6.0",
 ]
 maintainers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,9 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
+    "numpy<2.0; python_version in ['3.8', '3.9']",
+    "numpy; python_version >= '3.10'",
     "numba",
-    "numpy",
     "scipy>=1.1.0",
     "scikit-learn",
     "tables>=3.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "numpy",
     "scipy>=1.1.0",
     "scikit-learn",
-    "tables>=3.4.4",
+    "tables>=3.10",
     "traits>=6.0",
 ]
 maintainers = [


### PR DESCRIPTION
Allow Numpy version > 2.0 for Python 3.8, 3.10, 3.11 and 3.12

CI only fails for Python 3.9 when Numpy > 2.0 due to missing the most recent Pytables version. 