### PR TITLE
Reduce line length to 120

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -22,7 +22,6 @@ ignore = [
     "COM812", # conflict with ruff formatter 
     "ISC001", # conflict with ruff formatter
     # D
-    "D203", # don't enforce blank line before docstring
     "D401", # first line should be in imperative mood -> TBD
     "D205", # 1 blank line required between summary line and description -> should be fixed by issue #216
     "D100", # missing docstring in public module -> should be fixed by issue #216

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -18,7 +18,6 @@ select = [
         ]
 
 ignore = [
-    "E501", # ignore line length until fixed through issue #214
     "C901", # do we want to measure code complexity -> TBD
     "COM812", # conflict with ruff formatter 
     "ISC001", # conflict with ruff formatter

--- a/acoular/base.py
+++ b/acoular/base.py
@@ -38,9 +38,10 @@ class Generator(HasPrivateTraits):
 
     It provides a common interface for all classes, which generate an output via the generator :meth:`result`
     in block-wise manner. It has a common set of traits that are used by all classes that implement this interface.
-    This includes the sampling frequency of the signal (:attr:`sample_freq`) and the number of samples (:attr:`numsamples`).
-    A private trait :attr:`digest` is used to store the internal identifier of the object, which is a hash of the object's
-    attributes. This is used to check if the object's internal state has changed.
+    This includes the sampling frequency of the signal (:attr:`sample_freq`)
+    and the number of samples (:attr:`numsamples`).
+    A private trait :attr:`digest` is used to store the internal identifier of the object, which is a hash of the
+    object's attributes. This is used to check if the object's internal state has changed.
     """
 
     #: Sampling frequency of the signal, defaults to 1.0
@@ -75,8 +76,9 @@ class Generator(HasPrivateTraits):
 class SamplesGenerator(Generator):
     """Interface for any generating multi-channel time domain signal processing block.
 
-    It provides a common interface for all SamplesGenerator classes, which generate an output via the generator :meth:`result`
-    in block-wise manner. This class has no real functionality on its own and should not be used directly.
+    It provides a common interface for all SamplesGenerator classes, which generate an output
+    via the generator :meth:`result` in block-wise manner. This class has no real functionality on its own
+    and should not be used directly.
     """
 
     #: Number of channels
@@ -107,8 +109,9 @@ class SamplesGenerator(Generator):
 class SpectraGenerator(Generator):
     """Interface for any generating multi-channel signal frequency domain processing block.
 
-    It provides a common interface for all SpectraGenerator classes, which generate an output via the generator :meth:`result`
-    in block-wise manner. This class has no real functionality on its own and should not be used directly.
+    It provides a common interface for all SpectraGenerator classes, which generate an output
+    via the generator :meth:`result` in block-wise manner. This class has no real functionality on its own
+    and should not be used directly.
     """
 
     #: Number of channels

--- a/acoular/fastFuncs.py
+++ b/acoular/fastFuncs.py
@@ -9,7 +9,8 @@ import numba as nb
 import numpy as np
 
 CACHED_OPTION = True  # if True: saves the numba func as compiled func in sub directory
-PARALLEL_OPTION = 'parallel'  # if numba.guvectorize is used: 'CPU' for single threading; 'parallel' for multithreading; 'cuda' for calculating on GPU
+PARALLEL_OPTION = 'parallel'  # if numba.guvectorize is used: 'CPU' for single threading; 'parallel' for multithreading;
+# 'cuda' for calculating on GPU
 FAST_OPTION = True  # fastmath options
 
 
@@ -98,13 +99,14 @@ def beamformerFreq(steerVecType, boolRemovedDiagOfCSM, normFactor, inputTupleSte
     -------
     *Autopower spectrum beamforming map [nGridPoints]
 
-    *steer normalization factor [nGridPoints]... contains the values the autopower needs to be multiplied with, in order to
-    fullfill 'steer^H * steer = 1' as needed for functional beamforming.
+    *steer normalization factor [nGridPoints]... contains the values the autopower needs to be multiplied with,
+    in order to fullfill 'steer^H * steer = 1' as needed for functional beamforming.
 
     Some Notes on the optimization of all subroutines
     -------------------------------------------------
     Reducing beamforming equation:
-        Let the csm be C and the steering vector be h, than, using Linear Albegra, the conventional beamformer can be written as
+        Let the csm be C and the steering vector be h, than, using Linear Albegra,
+        the conventional beamformer can be written as
 
         .. math:: B = h^H \\cdot C \\cdot h,
         with ^H meaning the complex conjugated transpose.
@@ -134,7 +136,7 @@ def beamformerFreq(steerVecType, boolRemovedDiagOfCSM, normFactor, inputTupleSte
         "eigenVec.conj * steeringVector". BUT (at the moment) this only brings benefits in comp-time for a very
         small range of nMics (approx 250) --> Therefor it is not implemented here.
 
-    """
+    """  # noqa: E501
     boolIsEigValProb = isinstance(inputTupleCsm, tuple)  # len(inputTupleCsm) > 1
     # get the beamformer type (key-tuple = (isEigValProblem, formulationOfSteeringVector, RemovalOfCSMDiag))
     beamformerDict = {
@@ -231,14 +233,16 @@ def _freqBeamformer_FullCSM(
     result,
     normalizeSteer,
 ):
-    # see bottom of information header of 'beamformerFreq' for information on which steps are taken, in order to gain speed improvements.
+    # see bottom of information header of 'beamformerFreq' for information on which steps are taken,
+    # in order to gain speed improvements.
     nMics = csm.shape[0]
     st2 = steer_type == 2
     st34 = steer_type == 3 or steer_type == 4
     helpNormalize = 0.0  # just a hint for the compiler
     for gi in nb.prange(distGridToArrayCenter.shape[0]):
         steerVec = np.empty((nMics), np.complex128)
-        # building steering vector: in order to save some operation -> some normalization steps are applied after mat-vec-multipl.
+        # building steering vector:
+        # in order to save some operation -> some normalization steps are applied after mat-vec-multipl.
         for cntMics in range(nMics):
             expArg = np.float32(waveNumber * distGridToAllMics[gi, cntMics])
             steerVec[cntMics] = np.cos(expArg) - 1j * np.sin(expArg)
@@ -322,7 +326,8 @@ def _freqBeamformer_EigValues(
     result,
     normalizeSteer,
 ):
-    # see bottom of information header of 'beamformerFreq' for information on which steps are taken, in order to gain speed improvements.
+    # see bottom of information header of 'beamformerFreq' for information on which steps are taken,
+    # in order to gain speed improvements.
     nMics = eigVec.shape[0]
     nEigs = len(eigVal)
     st2 = steer_type == 2
@@ -330,7 +335,8 @@ def _freqBeamformer_EigValues(
     helpNormalize = 0.0  # just a hint for the compiler
     for gi in nb.prange(distGridToArrayCenter.shape[0]):
         steerVec = np.empty((nMics), np.complex128)
-        # building steering vector: in order to save some operation -> some normalization steps are applied after mat-vec-multipl.
+        # building steering vector:
+        # in order to save some operation -> some normalization steps are applied after mat-vec-multipl.
         for cntMics in range(nMics):
             expArg = np.float32(waveNumber * distGridToAllMics[gi, cntMics])
             steerVec[cntMics] = np.cos(expArg) - 1j * np.sin(expArg)
@@ -394,7 +400,8 @@ def _freqBeamformer_EigValues(
     fastmath=FAST_OPTION,
 )
 def _freqBeamformer_SpecificSteerVec_FullCSM(csm, steerVec, signalLossNormalization, result, normalizeSteer):
-    # see bottom of information header of 'beamformerFreq' for information on which steps are taken, in order to gain speed improvements.
+    # see bottom of information header of 'beamformerFreq' for information on which steps are taken,
+    # in order to gain speed improvements.
     nMics = csm.shape[0]
 
     # performing matrix-vector-multiplication (see bottom of information header of 'beamformerFreq')
@@ -424,7 +431,8 @@ def _freqBeamformer_SpecificSteerVec_FullCSM(csm, steerVec, signalLossNormalizat
     fastmath=FAST_OPTION,
 )
 def _freqBeamformer_SpecificSteerVec_CsmRemovedDiag(csm, steerVec, signalLossNormalization, result, normalizeSteer):
-    # see bottom of information header of 'beamformerFreq' for information on which steps are taken, in order to gain speed improvements.
+    # see bottom of information header of 'beamformerFreq' for information on which steps are taken,
+    # in order to gain speed improvements.
     nMics = csm.shape[0]
 
     # performing matrix-vector-multiplication (see bottom of information header of 'beamformerFreq')
@@ -458,7 +466,8 @@ def _freqBeamformer_EigValProb_SpecificSteerVec_FullCSM(
     result,
     normalizeSteer,
 ):
-    # see bottom of information header of 'beamformerFreq' for information on which steps are taken, in order to gain speed improvements.
+    # see bottom of information header of 'beamformerFreq' for information on which steps are taken,
+    # in order to gain speed improvements.
     nMics = eigVec.shape[0]
 
     # get h^H * h for normalization
@@ -494,7 +503,8 @@ def _freqBeamformer_EigValProb_SpecificSteerVec_CsmRemovedDiag(
     result,
     normalizeSteer,
 ):
-    # see bottom of information header of 'beamformerFreq' for information on which steps are taken, in order to gain speed improvements.
+    # see bottom of information header of 'beamformerFreq' for information on which steps are taken,
+    # in order to gain speed improvements.
     nMics = eigVec.shape[0]
 
     # get h^H * h for normalization
@@ -554,15 +564,16 @@ def calcPointSpreadFunction(steerVecType, distGridToArrayCenter, distGridToAllMi
 
         .. math:: B = \\left| h^H \\cdot a_S \\right| ^ 2.
     Steering vector:
-        Theoretically the steering vector always includes the term "exp(distMicsGrid - distArrayCenterGrid)", but as the steering vector gets multplied with its complex conjugation in
-        all beamformer routines, the constant "distArrayCenterGrid" cancels out --> In order to save operations, it is not implemented.
+        Theoretically the steering vector always includes the term "exp(distMicsGrid - distArrayCenterGrid)", but as the
+        steering vector gets multplied with its complex conjugation in all beamformer routines,
+        the constant "distArrayCenterGrid" cancels out --> In order to save operations, it is not implemented.
     Squares:
         Seemingly "a * a" is slightly faster than "a**2" in numba
     Square of abs():
-        Even though "a.real**2 + a.imag**^2" would have fewer operations, modern processors seem to be optimized for "a * a.conj" and are slightly faster the latter way.
-        Both Versions are much faster than "abs(a)**2".
+        Even though "a.real**2 + a.imag**^2" would have fewer operations, modern processors seem to be optimized
+        for "a * a.conj" and are slightly faster the latter way. Both Versions are much faster than "abs(a)**2".
 
-    """
+    """  # noqa: E501
     # get the steering vector formulation
     psfDict = {
         'classic': _psf_Formulation1AkaClassic,
@@ -613,7 +624,8 @@ def _psf_Formulation1AkaClassic(
 ):  # noqa ARG001
     nMics = distGridToAllMics.shape[0]
     for cntSources in range(len(distSourcesToArrayCenter)):
-        # see bottom of information header of 'calcPointSpreadFunction' for infos on the PSF calculation and speed improvements.
+        # see bottom of information header of 'calcPointSpreadFunction'
+        # for infos on the PSF calculation and speed improvements.
         scalarProd = 0.0 + 0.0j
         for cntMics in range(nMics):
             expArg = np.float32(
@@ -646,7 +658,8 @@ def _psf_Formulation2AkaInverse(
 ):
     nMics = distGridToAllMics.shape[0]
     for cntSources in range(len(distSourcesToArrayCenter)):
-        # see bottom of information header of 'calcPointSpreadFunction' for infos on the PSF calculation and speed improvements.
+        # see bottom of information header of 'calcPointSpreadFunction'
+        # for infos on the PSF calculation and speed improvements.
         scalarProd = 0.0 + 0.0j
         for cntMics in range(nMics):
             expArg = np.float32(
@@ -683,7 +696,8 @@ def _psf_Formulation3AkaTrueLevel(
 ):
     nMics = distGridToAllMics.shape[0]
     for cntSources in range(len(distSourcesToArrayCenter)):
-        # see bottom of information header of 'calcPointSpreadFunction' for infos on the PSF calculation and speed improvements.
+        # see bottom of information header of 'calcPointSpreadFunction'
+        # for infos on the PSF calculation and speed improvements.
         scalarProd = 0.0 + 0.0j
         helpNormalizeGrid = 0.0
         for cntMics in range(nMics):
@@ -722,7 +736,8 @@ def _psf_Formulation4AkaTrueLocation(
 ):  # noqa ARG001
     nMics = distGridToAllMics.shape[0]
     for cntSources in range(len(distSourcesToArrayCenter)):
-        # see bottom of information header of 'calcPointSpreadFunction' for infos on the PSF calculation and speed improvements.
+        # see bottom of information header of 'calcPointSpreadFunction'
+        # for infos on the PSF calculation and speed improvements.
         scalarProd = 0.0 + 0.0j
         helpNormalizeGrid = 0.0
         for cntMics in range(nMics):
@@ -747,7 +762,8 @@ def _psf_Formulation4AkaTrueLocation(
 # def _psf_SpecificSteerVec(steerVec, steerVecSources, result):
 #    nMics = len(steerVec)
 #    for cntSources in range(steerVecSources.shape[0]):
-#        # see bottom of information header of 'calcPointSpreadFunction' for infos on the PSF calculation and speed improvements.
+#        # see bottom of information header of 'calcPointSpreadFunction'
+#        # for infos on the PSF calculation and speed improvements.
 #        scalarProd = 0.0 + 0.0j
 #        for cntMics in range(nMics):
 #            scalarProd += steerVec[cntMics].conjugate() * steerVecSources[cntSources, cntMics]

--- a/acoular/fbeamform.py
+++ b/acoular/fbeamform.py
@@ -820,7 +820,8 @@ class BeamformerFunctional(BeamformerBase):
     #: Functional Beamforming is only well defined for full CSM
     r_diag = Enum(False, desc='False, as Functional Beamformer is only well defined for the full CSM')
 
-    #: Normalization factor in case of CSM diagonal removal. Defaults to 1.0 since Functional Beamforming is only well defined for full CSM.
+    #: Normalization factor in case of CSM diagonal removal.
+    #: Defaults to 1.0 since Functional Beamforming is only well defined for full CSM.
     r_diag_norm = Enum(
         1.0,
         desc='No normalization needed. Functional Beamforming is only well defined for full CSM.',
@@ -907,7 +908,8 @@ class BeamformerCapon(BeamformerBase):
     # for Capon beamforming r_diag is set to 'False'.
     r_diag = Enum(False, desc='removal of diagonal')
 
-    #: Normalization factor in case of CSM diagonal removal. Defaults to 1.0 since Beamformer Capon is only well defined for full CSM.
+    #: Normalization factor in case of CSM diagonal removal.
+    #: Defaults to 1.0 since Beamformer Capon is only well defined for full CSM.
     r_diag_norm = Enum(
         1.0,
         desc='No normalization. BeamformerCapon is only well defined for full CSM.',
@@ -1020,7 +1022,8 @@ class BeamformerMusic(BeamformerEig):
     # for MUSIC beamforming r_diag is set to 'False'.
     r_diag = Enum(False, desc='removal of diagonal')
 
-    #: Normalization factor in case of CSM diagonal removal. Defaults to 1.0 since BeamformerMusic is only well defined for full CSM.
+    #: Normalization factor in case of CSM diagonal removal.
+    #: Defaults to 1.0 since BeamformerMusic is only well defined for full CSM.
     r_diag_norm = Enum(
         1.0,
         desc='No normalization. BeamformerMusic is only well defined for full CSM.',
@@ -1208,10 +1211,14 @@ class PointSpreadFunction(HasPrivateTraits):
     #: Flag that defines how to calculate and store the point spread function
     #: defaults to 'single'.
     #:
-    #: * 'full': Calculate the full PSF (for all grid points) in one go (should be used if the PSF at all grid points is needed, as with :class:`DAMAS<BeamformerDamas>`)
-    #: * 'single': Calculate the PSF for the grid points defined by :attr:`grid_indices`, one by one (useful if not all PSFs are needed, as with :class:`CLEAN<BeamformerClean>`)
-    #: * 'block': Calculate the PSF for the grid points defined by :attr:`grid_indices`, in one go (useful if not all PSFs are needed, as with :class:`CLEAN<BeamformerClean>`)
-    #: * 'readonly': Do not attempt to calculate the PSF since it should already be cached (useful if multiple processes have to access the cache file)
+    #: * 'full': Calculate the full PSF (for all grid points) in one go
+    #:     * (should be used if the PSF at all grid points is needed, as with :class:`DAMAS<BeamformerDamas>`)
+    #: * 'single': Calculate the PSF for the grid points defined by :attr:`grid_indices`, one by one
+    #:     * (useful if not all PSFs are needed, as with :class:`CLEAN<BeamformerClean>`)
+    #: * 'block': Calculate the PSF for the grid points defined by :attr:`grid_indices`, in one go
+    #:     * (useful if not all PSFs are needed, as with :class:`CLEAN<BeamformerClean>`)
+    #: * 'readonly': Do not attempt to calculate the PSF since it should already be cached
+    #:     * (useful if multiple processes have to access the cache file)
     calcmode = Trait('single', 'block', 'full', 'readonly', desc='mode of calculation / storage')
 
     #: Floating point precision of property psf. Corresponding to numpy dtypes. Default = 64 Bit.
@@ -1751,7 +1758,8 @@ class BeamformerCleansc(BeamformerBase):
                 hh = hh[:, newaxis]
                 csm1 = hmax * (hh * hh.conj().T)
 
-                # h1 = self.steer._beamformerCall(f[i], self.r_diag, normfactor, (array((hmax, ))[newaxis, :], hh[newaxis, :].conjugate()))[0]
+                # h1 = self.steer._beamformerCall(f[i], self.r_diag, normfactor, (array((hmax, ))[newaxis, :],
+                #                                 hh[newaxis, :].conjugate()))[0]
                 h1 = beamformerFreq(
                     param_steer_type,
                     self.r_diag,
@@ -2428,7 +2436,8 @@ class BeamformerGIB(BeamformerEig):  # BeamformerEig #BeamformerBase
                                     emode,
                                 )
                             if self.beta < 1 and it > 1:
-                                # Reorder from the greatest to smallest magnitude to define a reduced-point source distribution , and reform a reduced transfer matrix
+                                # Reorder from the greatest to smallest magnitude to define a reduced-point source
+                                # distribution , and reform a reduced transfer matrix
                                 leftpoints = int(round(numpoints * self.beta ** (it + 1)))
                                 idx = argsort(abs(qi[s, locpoints]))[::-1]
                                 # print(it, leftpoints, locpoints, idx )

--- a/acoular/fprocess.py
+++ b/acoular/fprocess.py
@@ -37,8 +37,8 @@ class RFFT(BaseSpectra, SpectraOut):
     #: Data source; :class:`~acoular.base.SamplesGenerator` or derived object.
     source = Instance(SamplesGenerator)
 
-    #: Number of workers to use for the FFT calculation. If negative values are used,
-    #: all available logical CPUs will be considered (``scipy.fft.rfft`` implementation wraps around from ``os.cpu_count()``).
+    #: Number of workers to use for the FFT calculation. If negative values are used, all available logical CPUs will be
+    #: considered (``scipy.fft.rfft`` implementation wraps around from ``os.cpu_count()``).
     #: Default is `None` (handled by scipy)
     workers = Union(Int(), None, default_value=None, desc='number of workers to use')
 
@@ -152,8 +152,8 @@ class IRFFT(TimeOut):
     #: Data source; :class:`~acoular.base.SpectraGenerator` or derived object.
     source = Instance(SpectraGenerator)
 
-    #: Number of workers to use for the FFT calculation. If negative values are used,
-    #: all available logical CPUs will be considered (``scipy.fft.rfft`` implementation wraps around from ``os.cpu_count()``).
+    #: Number of workers to use for the FFT calculation. If negative values are used, all available logical CPUs will be
+    #: considered (``scipy.fft.rfft`` implementation wraps around from ``os.cpu_count()``).
     #: Default is `None` (handled by scipy)
     workers = Union(Int(), None, default_value=None, desc='number of workers to use')
 

--- a/acoular/process.py
+++ b/acoular/process.py
@@ -282,8 +282,12 @@ class Cache(InOut):
                 elif not self.h5f.get_data_by_reference(nodename).attrs['complete']:
                     if config.global_caching == 'readonly':
                         warn(
-                            "Cache file is incomplete for nodename %s. With config.global_caching='readonly', the cache file will not be used!"
-                            % str(nodename),
+                            ' '.join(
+                                [
+                                    f'Cache file is incomplete for nodename {str(nodename)}.',
+                                    "With config.global_caching='readonly', the cache file will not be used!",
+                                ]
+                            ),
                             Warning,
                             stacklevel=1,
                         )

--- a/acoular/spectra.py
+++ b/acoular/spectra.py
@@ -712,7 +712,12 @@ class PowerSpectraImport(PowerSpectra):
 
     def _set_csm(self, csm):
         if (len(csm.shape) != 3) or (csm.shape[1] != csm.shape[2]):
-            msg = 'The cross spectral matrix must have the following shape: (number of frequencies, numchannels, numchannels)!'
+            msg = ' '.join(
+                [
+                    'The cross spectral matrix must have the following shape:',
+                    '(number of frequencies, numchannels, numchannels)!',
+                ]
+            )
             raise ValueError(msg)
         self._csmsum = real(self._csm).sum() + (imag(self._csm) ** 2).sum()  # to trigger new digest creation
         self._csm = csm

--- a/acoular/tbeamform.py
+++ b/acoular/tbeamform.py
@@ -114,7 +114,8 @@ class BeamformerTime(TimeOut):
 
     def _set_steer(self, steer):
         if type(steer) == SteeringVector:
-            # This condition may be replaced at a later time by: isinstance(steer, SteeringVector): -- (derived classes allowed)
+            # This condition may be replaced at a later time by:
+            # isinstance(steer, SteeringVector): -- (derived classes allowed)
             self._steer_obj = steer
         elif steer in ('true level', 'true location', 'classic', 'inverse'):
             # Type of steering vectors, see also :ref:`Sarradj, 2012<Sarradj2012>`.

--- a/acoular/tprocess.py
+++ b/acoular/tprocess.py
@@ -436,8 +436,13 @@ class Trigger(TimeOut):
         faultyInd = flatnonzero(diffDist > self.max_variation_of_duration * meanDist)
         if faultyInd.size != 0:
             warn(
-                'In Trigger-Identification: The distances between the peaks (and therefor the lengths of the revolutions) vary too much (check samples %s).'
-                % str(peakLoc[faultyInd] + self.source.start),
+                ' '.join(
+                    [
+                        'In Trigger-Identification: The distances between the peaks',
+                        '(and therefor the lengths of the revolutions) vary too much',
+                        f'(check samples {str(peakLoc[faultyInd] + self.source.start)}).',
+                    ]
+                ),
                 Warning,
                 stacklevel=2,
             )
@@ -767,20 +772,22 @@ class SpatialInterpolator(TimeOut):
                 1. item : float64[nMicsInSpecificSubarray]
                     Ordered positions of the real mics on the new 1d axis, to be used as inputs for numpys interp.
                 2. item : int64[nMicsInArray]
-                    Indices identifying how the measured pressures must be evaluated, s.t. the entries of the previous item (see last line)
-                    correspond to their initial pressure values
+                    Indices identifying how the measured pressures must be evaluated, s.t. the entries of the previous
+                    item (see last line) correspond to their initial pressure values
             If the Array is 2D or 3d the list items are:
                 1. item : Delaunay mesh object
                     Delauney mesh (see scipy.spatial.Delaunay) for the specific Array
                 2. item : int64[nMicsInArray]
-                    same as 1d case, BUT with the difference, that here the rotational periodicy is handled, when constructing the mesh.
-                    Therefor the mesh could have more vertices than the actual Array mics.
+                    same as 1d case, BUT with the difference, that here the rotational periodicy is handled,
+                    when constructing the mesh. Therefor the mesh could have more vertices than the actual Array mics.
 
         virtNewCoord : float64[3, nVirtualMics]
-            Projection of each virtual mic onto its new coordinates. The columns of virtNewCoord correspond to [phi, rho, z]
+            Projection of each virtual mic onto its new coordinates.
+            The columns of virtNewCoord correspond to [phi, rho, z]
 
         newCoord : float64[3, nMics]
-            Projection of each mic onto its new coordinates. The columns of newCoordinates correspond to [phi, rho, z]
+            Projection of each mic onto its new coordinates.
+            The columns of newCoordinates correspond to [phi, rho, z]
 
         """
         # init positions of virtual mics in cyl coordinates
@@ -886,7 +893,14 @@ class SpatialInterpolator(TimeOut):
 
         return mesh, virtNewCoord, newCoord
 
-    def _result_core_func(self, p, phi_delay=None, period=None, Q=Q, interp_at_zero=False):  # noqa: N803, ARG002 (see #226)
+    def _result_core_func(
+        self,
+        p,
+        phi_delay=None,
+        period=None,
+        Q=Q,  # noqa: N803, ARG002 (see #226)
+        interp_at_zero=False,  # noqa: ARG002 (see #226)
+    ):
         """Performs the actual Interpolation.
 
         Parameters
@@ -2072,7 +2086,12 @@ class MaskedTimeInOut(MaskedTimeOut):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         warn(
-            'Using MaskedTimeInOut is deprecated and will be removed in Acoular version 25.07. Use class MaskedTimeOut instead.',
+            ' '.join(
+                [
+                    'Using MaskedTimeInOut is deprecated and will be removed in Acoular version 25.07.',
+                    'Use class MaskedTimeOut instead.',
+                ]
+            ),
             DeprecationWarning,
             stacklevel=2,
         )

--- a/docs/source/news/index.rst
+++ b/docs/source/news/index.rst
@@ -7,6 +7,7 @@ Upcoming Release (25.01)
     **New features:**
     
     **Bugfixes**
+        * reduces (almost) all line lengths to 120 characters or less
 
     **Documentation**
 

--- a/examples/io_and_signal_processing_examples/example_fft.py
+++ b/examples/io_and_signal_processing_examples/example_fft.py
@@ -51,8 +51,8 @@ print(
     np.round((1 / block_size * np.sum(spec * spec.conjugate())).real),
 )
 
-# It can be seen, that the energy is not preserved when using the default 'none' scaling.
-# Therefore, we set the scaling to 'energy' to compensate for the energy loss due to truncation to a single-sided spectrum.
+# It can be seen, that the energy is not preserved when using the default 'none' scaling. Therefore, we set the scaling
+# to 'energy' to compensate for the energy loss due to truncation to a single-sided spectrum.
 
 fft.scaling = 'energy'
 spec = next(fft.result(num=1))[0]
@@ -101,7 +101,8 @@ plt.show()
 # %%
 # Create an averaged power spectral density of the signal
 # --------------------------------------------------------
-# To calculate the time averaged power spectral density of the signal, we use the :class:`acoular.fprocess.AutoPowerSpectra` class.
+# To calculate the time averaged power spectral density of the signal,
+# we use the :class:`acoular.fprocess.AutoPowerSpectra` class.
 
 fft.scaling = 'none'
 ap = ac.AutoPowerSpectra(source=fft, scaling='psd')  # results in the power spectrum

--- a/examples/io_and_signal_processing_examples/example_power_spectra_import.py
+++ b/examples/io_and_signal_processing_examples/example_power_spectra_import.py
@@ -7,7 +7,8 @@ Cross-spectral matrix import
 ============================
 
 This example demonstrates how to import a cross-spectral matrix from a external source
-by means of the :class:`acoular.spectra.PowerSpectraImport` class. The CSM is created numerically for a frequency of 8 kHz.
+by means of the :class:`acoular.spectra.PowerSpectraImport` class.
+The CSM is created numerically for a frequency of 8 kHz.
 """
 
 from pathlib import Path

--- a/examples/wind_tunnel_examples/example_airfoil_in_open_jet_cmf.py
+++ b/examples/wind_tunnel_examples/example_airfoil_in_open_jet_cmf.py
@@ -46,7 +46,8 @@ if not time_data_file.exists():
 # Setting up the processing chain for :class:`acoular.fbeamform.BeamformerCMF` methods.
 #
 # .. hint::
-#    A step-by-step explanation for setting up the processing chain is given in the example :doc:`example_airfoil_in_open_jet_steering_vectors`.
+#    A step-by-step explanation for setting up the processing chain is given
+#    in the example :doc:`example_airfoil_in_open_jet_steering_vectors`.
 
 ts = ac.MaskedTimeSamples(
     name=time_data_file,

--- a/examples/wind_tunnel_examples/example_airfoil_in_open_jet_freq_domain_methods.py
+++ b/examples/wind_tunnel_examples/example_airfoil_in_open_jet_freq_domain_methods.py
@@ -47,7 +47,8 @@ num = 3
 # Setting up the processing chain for the frequency domain methods.
 #
 # .. hint::
-#    An in-depth explanation for setting up the processing chain is given in the example :doc:`example_airfoil_in_open_jet_steering_vectors`.
+#    An in-depth explanation for setting up the processing chain
+#    is given in the example :doc:`example_airfoil_in_open_jet_steering_vectors`.
 
 
 ts = ac.MaskedTimeSamples(
@@ -65,8 +66,9 @@ f = ac.PowerSpectra(source=ts, window='Hanning', overlap='50%', block_size=128)
 
 
 # %%
-# Here, different frequency domain beamformers defined in the module :mod:`acoular.fbeamform` are used and the corresponding result maps are calculated by
-# evaluating the :meth:`acoular.fbeamform.BeamformerBase.synthetic` method with the desired frequency and bandwidth.
+# Here, different frequency domain beamformers defined in the module :mod:`acoular.fbeamform` are used
+# and the corresponding result maps are calculated by evaluating the :meth:`acoular.fbeamform.BeamformerBase.synthetic`
+# method with the desired frequency and bandwidth.
 
 bb = ac.BeamformerBase(freq_data=f, steer=st, r_diag=True)
 bc = ac.BeamformerCapon(freq_data=f, steer=st, cached=False)

--- a/examples/wind_tunnel_examples/example_airfoil_in_open_jet_steering_vectors.py
+++ b/examples/wind_tunnel_examples/example_airfoil_in_open_jet_steering_vectors.py
@@ -62,7 +62,8 @@ t1.invalid_channels = invalid
 t1.calib = ac.Calib(from_file=calib_file)
 
 # %%
-# The microphone geometry must have the same number of valid channels as the :class:`acoular.sources.MaskedTimeSamples` object has.
+# The microphone geometry must have the same number of valid channels
+# as the :class:`acoular.sources.MaskedTimeSamples` object has.
 # It also must be defined, which channels are invalid.
 
 micgeofile = Path(ac.__file__).parent / 'xml' / 'array_56.xml'
@@ -70,20 +71,23 @@ m = ac.MicGeom(from_file=micgeofile)
 m.invalid_channels = invalid
 
 # %%
-# Next, we define a planar rectangular grid for calculating the beamforming map (the example grid is very coarse for computational efficiency).
+# Next, we define a planar rectangular grid for calculating the beamforming map
+# (the example grid is very coarse for computational efficiency).
 # A 3D grid is also available via the :class:`acoular.grids.RectGrid3D` class.
 
 g = ac.RectGrid(x_min=-0.6, x_max=-0.0, y_min=-0.3, y_max=0.3, z=0.68, increment=0.05)
 
 # %%
-# For frequency domain methods, :class:`acoular.spectra.PowerSpectra` provides the cross spectral matrix (and its
-# eigenvalues and eigenvectors). Here, we use the Welch's method with a block size of 128 samples, Hanning window and 50% overlap.
+# For frequency domain methods, :class:`acoular.spectra.PowerSpectra` provides the cross spectral matrix
+# (and its eigenvalues and eigenvectors). Here, we use the Welch's method with a block size of 128 samples,
+# Hanning window and 50% overlap.
 
 f = ac.PowerSpectra(source=t1, window='Hanning', overlap='50%', block_size=128)
 
 # %%
-# To define the measurement environment, i.e. medium characteristics, the :class:`acoular.environment.Environment` class is used.
-# (in this case, only the speed of sound is set)
+# To define the measurement environment, i.e. medium characteristics,
+# the :class:`acoular.environment.Environment` class is used.
+# (In this case, only the speed of sound is set)
 
 env = ac.Environment(c=346.04)
 
@@ -94,14 +98,15 @@ env = ac.Environment(c=346.04)
 st = ac.SteeringVector(grid=g, mics=m, env=env)
 
 # %%
-# Finally, we define two different beamformers and subsequently calculate the maps for different steering vector formulations.
-# Diagonal removal for the CSM can be performed via the :attr:`r_diag` parameter.
+# Finally, we define two different beamformers and subsequently calculate the maps for different steering vector
+# formulations. Diagonal removal for the CSM can be performed via the :attr:`r_diag` parameter.
 
 bb = ac.BeamformerBase(freq_data=f, steer=st, r_diag=True)
 bs = ac.BeamformerCleansc(freq_data=f, steer=st, r_diag=True)
 
 # %%
-# Plot result maps for different beamformers in frequency domain (left: with diagonal removal, right: without diagonal removal).
+# Plot result maps for different beamformers in frequency domain
+# (left: with diagonal removal, right: without diagonal removal).
 
 from pylab import colorbar, figure, imshow, show, subplot, tight_layout, title
 
@@ -127,4 +132,5 @@ for r_diag in (True, False):
 
 # %%
 # .. seealso::
-#    :doc:`example_airfoil_in_open_jet_freq_domain_methods` for an application of further frequency domain methods on the same data.
+#    :doc:`example_airfoil_in_open_jet_freq_domain_methods` for an application
+#    of further frequency domain methods on the same data.

--- a/examples/wind_tunnel_examples/example_airfoil_in_open_jet_time_domain_methods.py
+++ b/examples/wind_tunnel_examples/example_airfoil_in_open_jet_time_domain_methods.py
@@ -88,7 +88,8 @@ avgts = ac.Average(source=bts, naverage=1024)
 cachts = ac.Cache(source=avgts)  # cache to prevent recalculation
 
 # %%
-# Third, CLEAN deconvolution in the time domain (CLEAN-T) is applied, using the :class:`acoular.tbeamform.BeamformerCleant` class.
+# Third, CLEAN deconvolution in the time domain (CLEAN-T) is applied,
+# using the :class:`acoular.tbeamform.BeamformerCleant` class.
 fct = ac.FiltFiltOctave(source=ts, band=cfreq)
 bct = ac.BeamformerCleant(source=fct, steer=st, n_iter=20, damp=0.7)
 ptct = ac.TimePower(source=bct)
@@ -96,7 +97,8 @@ avgct = ac.Average(source=ptct, naverage=1024)
 cachct = ac.Cache(source=avgct)  # cache to prevent recalculation
 
 # %%
-# Finally, squared signals with autocorrelation removal can be obtained by using the :class:`acoular.tbeamform.BeamformerCleantSq` class.
+# Finally, squared signals with autocorrelation removal can be obtained
+# by using the :class:`acoular.tbeamform.BeamformerCleantSq` class.
 fcts = ac.FiltFiltOctave(source=ts, band=cfreq)
 bcts = ac.BeamformerCleantSq(source=fcts, steer=st, n_iter=20, damp=0.7, r_diag=True)
 avgcts = ac.Average(source=bcts, naverage=1024)

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -40,7 +40,8 @@ from numpy import array
 UNEQUAL_DIGEST_TEST_DICT = {
     #    "MicGeom.mpos_tot item assignment" : (MicGeom(mpos_tot=[[1.,2.,3.]]), "obj.mpos_tot[:] = 0."),
     'MicGeom.mpos_tot new array assignment': (MicGeom(mpos_tot=[[1.0, 2.0, 3.0]]), 'obj.mpos_tot = array([0.])'),
-    #    "MicGeom.invalid_channels item assignment" : (MicGeom(mpos_tot=[[1.,2.,3.]],invalid_channels=[1]), "obj.invalid_channels[0] = 0"),
+    #    "MicGeom.invalid_channels item assignment" : (MicGeom(mpos_tot=[[1.,2.,3.]],invalid_channels=[1]),
+    #                                                  "obj.invalid_channels[0] = 0"),
     'MicGeom.invalid_channels new list assignment': (
         MicGeom(mpos_tot=[[1.0, 2.0, 3.0]], invalid_channels=[1]),
         'obj.invalid_channels = [0]',
@@ -83,12 +84,14 @@ UNEQUAL_DIGEST_TEST_DICT = {
         'obj.invalid_channels[0] = 0',
     ),
     'MaskedTimeSamples.invalid_channels list assignment': (MaskedTimeSamples(), 'obj.invalid_channels = [0]'),
-    #    "SphericalHarmonicSource.alpha item assignment": (SphericalHarmonicSource(alpha=array((0, 1))), "obj.alpha[0] = 1."),
+    #    "SphericalHarmonicSource.alpha item assignment": (SphericalHarmonicSource(alpha=array((0, 1))),
+    #                                                      "obj.alpha[0] = 1."),
     'SphericalHarmonicSource.alpha array assignment': (
         SphericalHarmonicSource(alpha=array((0, 1))),
         'obj.alpha = array((1., 1., 1.))',
     ),
-    #    "UncorrelatedNoiseSource.seed item assignment": (UncorrelatedNoiseSource(seed=array((1, 2))), "obj.seed[0] = 3"),
+    #    "UncorrelatedNoiseSource.seed item assignment": (UncorrelatedNoiseSource(seed=array((1, 2))),
+    #                                                     "obj.seed[0] = 3"),
     'UncorrelatedNoiseSource.seed array assignment': (
         UncorrelatedNoiseSource(seed=array((1, 2))),
         'obj.seed = array((3,4))',
@@ -133,7 +136,8 @@ UNEQUAL_DIGEST_TEST_DICT = {
         SpatialInterpolatorRotation(),
         'obj.Q = array([[0.,0.,0.],[0.,0.,0.],[0.,0.,0.]])',
     ),
-    #    "SpatialInterpolatorConstantRotation.Q item assignment": (SpatialInterpolatorConstantRotation(), "obj.Q[0] = 0."),
+    #    "SpatialInterpolatorConstantRotation.Q item assignment": (SpatialInterpolatorConstantRotation(),
+    #                                                              "obj.Q[0] = 0."),
     'SpatialInterpolatorConstantRotation.Q array assignment': (
         SpatialInterpolatorConstantRotation(),
         'obj.Q = array([[0.,0.,0.],[0.,0.,0.],[0.,0.,0.]])',


### PR DESCRIPTION
### Description
* reduces (almost) all lines to 120 characters or less

### Comments
I sometimes used the join method to split and recombine stings since simply adding two strings together with a "+" triggers another linting error.

I sometimes used "neqa: E501" since the docstring would have been broken upon splitting parameter datatype arguments.

### Issue
This PR is regarding issue #214.