### PR TITLE
Fix labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,27 +1,20 @@
 docs:
-- changed-files:
-  - any-glob-to-any-file:
-    - docs/**
-    - README.md
-    - AUTHORS.rst
-    - CITATION.cff
+- all:
+  - changed-files:
+    - any-glob-to-any-file: ['docs/**', 'README.md', 'AUTHORS.rst', 'CITATION.cff']
+    - all-globs-to-any-file: '!docs/source/news/index.rst'
 tests:
 - changed-files:
-  - any-glob-to-any-file:
-    - tests/**
+  - any-glob-to-any-file: 'tests/**'
 ci:
 - changed-files:
-  - any-glob-to-any-file: .github/**
+  - any-glob-to-any-file: '.github/**'
 linting:
 - changed-files:
-  - any-glob-to-any-file: .ruff.toml
+  - any-glob-to-any-file: '.ruff.toml'
 maintenance:
 - changed-files:
-  - any-glob-to-any-file:
-    - pyproject.toml
-    - CONTRIBUTING.md
-    - CODE_OF_CONDUCT.md
-    - LICENSE
+  - any-glob-to-any-file: ['pyproject.toml', 'CONTRIBUTING.md', 'CODE_OF_CONDUCT.md', 'LICENSE']
 new feature:
  - head-branch: ['^feature', 'feature']
 sinus:

--- a/docs/source/news/index.rst
+++ b/docs/source/news/index.rst
@@ -48,6 +48,7 @@ Upcoming Release (25.01)
         * `depends_on` now only accepts a list of strings
         * removes deprecated traits ending with version 25.01
         * include doctests in coverage report
+        * no longer add docs label if news/index.rst is updated
 
 24.10
 ----------------


### PR DESCRIPTION
Stops the docs label from being added, if `docs/news/index.rst` is edited.