### PR TITLE
Test traits dependencies

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -11,7 +11,7 @@ select = [
         "YTT", "ASYNC", "ASYNC1", "BLE", "B", "A", "COM", # flake8 plugins
         "C4", "DTZ","T10","EM", "FA", "ISC", "ICN", # flake8 plugins
         "LOG", "G", "INP", "PIE", "T20", "PYI", "PT", "RSE", # flake8 plugins
-        "RET", "SLF", "SLOT", "SIM", "TID", "TCH", "INT", "ARG", "TD", "FIX", # flake8 plugins
+        "RET", "SLF", "SLOT", "SIM", "TID", "TCH", "INT", "ARG", "TD", # flake8 plugins
         "C901" # others
         ]
 

--- a/acoular/environments.py
+++ b/acoular/environments.py
@@ -16,6 +16,7 @@
 
 """
 
+from abc import abstractmethod
 import numba as nb
 from numpy import (
     arange,
@@ -47,7 +48,7 @@ from scipy.integrate import ode
 from scipy.interpolate import LinearNDInterpolator
 from scipy.linalg import norm
 from scipy.spatial import ConvexHull
-from traits.api import CArray, Dict, Float, HasStrictTraits, Instance, Int, Property, Union, cached_property
+from traits.api import ABCHasStrictTraits, CArray, Dict, Float, HasStrictTraits, Instance, Int, Property, Union, cached_property
 
 from .internal import digest
 
@@ -252,14 +253,16 @@ class UniformFlowEnvironment(Environment):
         return rm
 
 
-class FlowField(HasStrictTraits):
+class FlowField(ABCHasStrictTraits):
     """An abstract base class for a spatial flow field."""
 
     digest = Property
 
+    @abstractmethod
     def _get_digest(self):
-        return ''
+        pass
 
+    @abstractmethod
     def v(self, xx):  # noqa: ARG002
         """Provides the flow field as a function of the location. This is
         implemented here for the possibly most simple case: a quiescent fluid.
@@ -278,10 +281,6 @@ class FlowField(HasStrictTraits):
             - jacobian_matrix : array of floats of shape (3, 3)
                 The Jacobian matrix of the velocity vector field at the given location.
         """
-        v = array((0.0, 0.0, 0.0))
-        dv = array(((0.0, 0.0, 0.0), (0.0, 0.0, 0.0), (0.0, 0.0, 0.0)))
-        return -v, -dv
-
 
 class SlotJet(FlowField):
     """Provides an analytical approximation of the flow field of a slot jet.

--- a/acoular/environments.py
+++ b/acoular/environments.py
@@ -276,8 +276,7 @@ class FlowField(ABCHasStrictTraits):
 
     @abstractmethod
     def v(self, xx):  # noqa: ARG002
-        """Provides the flow field as a function of the location. This is
-        implemented here for the possibly most simple case: a quiescent fluid.
+        """Provides the flow field as a function of the location.
 
         Parameters
         ----------

--- a/acoular/environments.py
+++ b/acoular/environments.py
@@ -294,6 +294,7 @@ class FlowField(ABCHasStrictTraits):
                 The Jacobian matrix of the velocity vector field at the given location.
         """
 
+
 class SlotJet(FlowField):
     """Provides an analytical approximation of the flow field of a slot jet.
 

--- a/acoular/environments.py
+++ b/acoular/environments.py
@@ -17,6 +17,7 @@
 """
 
 from abc import abstractmethod
+
 import numba as nb
 from numpy import (
     arange,
@@ -48,7 +49,18 @@ from scipy.integrate import ode
 from scipy.interpolate import LinearNDInterpolator
 from scipy.linalg import norm
 from scipy.spatial import ConvexHull
-from traits.api import ABCHasStrictTraits, CArray, Dict, Float, HasStrictTraits, Instance, Int, Property, Union, cached_property
+from traits.api import (
+    ABCHasStrictTraits,
+    CArray,
+    Dict,
+    Float,
+    HasStrictTraits,
+    Instance,
+    Int,
+    Property,
+    Union,
+    cached_property,
+)
 
 from .internal import digest
 

--- a/docs/source/news/index.rst
+++ b/docs/source/news/index.rst
@@ -3,7 +3,7 @@ What's new
 
 Upcoming Release (25.01)
 ------------------------
-    
+
     **New features:**
         * consistently use `file` as an attribute to specify a filename (instead of `from_file` or `name`)
         * adds new function :meth:`~acoular.tools.helper.c_air` to calculate the speed of sound from temperature and humidity
@@ -17,7 +17,7 @@ Upcoming Release (25.01)
         * pass missing `max_iter` as an argument to `LassoLarsCV` in :class:`acoular.fbeamform.BeamformerGIB` (otherwise, LassoLarsCV runs up to 500 iterations)
         * fix broken pylops solvers in :class:`acoular.fbeamform.BeamformerCMF`
         * fixes negative values in source maps obtained with the solvers `LassoLars`, `LassoLarsCV` and `LassoLarsBIC`
-        * fix use of Trait() factory and replace by Enum, Instance, Map, Union 
+        * fix use of Trait() factory and replace by Enum, Instance, Map, Union
 
     **Documentation**
         * adds guide on how to submit a pull request
@@ -26,7 +26,7 @@ Upcoming Release (25.01)
     **Tests**
         * tests now consequently use `pytest` framework instead of `unittest`
         * separate tests in into `tests/regression` and `tests/unittests` directories
-        * increases coverage to 76 % 
+        * increases coverage to 76 %
         * introduces snapshot / regression testing for all :class:`~acoular.base.Generator`, :class:`~acoular.fbeamform.BeamformerBase`, :class:`~acoular.environments.FlowField`, and :class:`~acoular.environments.Environment` derived classes (results in new snapshot data of size 1.1MB (see `tests/regression/_regtest_output`)
         * use `pytest-cases` to separate parameters from tests (cases are located under `tests/cases`)
         * full coverage of `sdinput.py` module through the use of `pytest-mock` (mocks the behavior of an InputStream object, which cannot be used for CI due to missing audio interfaces)
@@ -39,6 +39,7 @@ Upcoming Release (25.01)
         * fix a typo in `AngleTracker` that lead to a property being incorrectly accessed
         * exclude jited functions from test coverage report
         * treat warnings as errors in tests
+        * recursively tests for empty dependencies in `Property` traits that are depended on
 
     **Internal**
         * adds a pull request template
@@ -53,7 +54,7 @@ Upcoming Release (25.01)
 
 24.10
 ----------------
-    
+
     **New features:**
         * Sounddevice inputs now allow for user-settable sample rates and precision types
         * Block-wise frequency domain processing
@@ -64,8 +65,8 @@ Upcoming Release (25.01)
             * Deprecates: :class:`~acoular.base.TimeInOut`, :class:`~acoular.fprocess.FFTSpectra`, :class:`~acoular.process.TimeAverage`, :class:`~acoular.tprocess.MaskedTimeInOut`, :class:`~acoular.process.TimeCache`
             * adds unittests `test_process.py`, `test_fprocess.py`
             * adds documentation example `example_fft.py`
-                * allow more platforms to build the docs files including Linux, MacOS, and Windows 
-    
+                * allow more platforms to build the docs files including Linux, MacOS, and Windows
+
     **Bugfixes**
         * flush file in :class:`~acoular.tprocess.TimeCache` to prevent data loss / corruption
         * fixes use of already deprecated traits
@@ -82,7 +83,7 @@ Upcoming Release (25.01)
 
     **Internal**
         * refactoring of classes in :mod:`acoular.tbeamform` (moves buffer logic away from Beamformer classes)
-            * adds new :class:`~acoular.tools.utils.SamplesBuffer` class located in :mod:`~acoular.tools.utils` 
+            * adds new :class:`~acoular.tools.utils.SamplesBuffer` class located in :mod:`~acoular.tools.utils`
         * replaces the markdown-link-check by lychee
             * faster CI (written in RUST)
             * allows more files to be checked, including the .rst files in the documentation
@@ -100,7 +101,7 @@ Upcoming Release (25.01)
         * Implement a lazy result array for :class:`acoular.fbeamform.BeamformerBase` derived classes
         * Adds flow establishment length traits
         * Updates acoular demo with ASCII map and gets rid of writing file
-    
+
     Bugfixes:
         * temporary fix to PyTables - NumPy 2.0 incompatibility problem
         * Fixes :class:`acoular.fbeamform.BeamformerGridlessOrth` `shgo` params and `eva_list` initial value bug
@@ -111,7 +112,7 @@ Upcoming Release (25.01)
         * add issue templates
         * adds Conda CI
         * CI for TestPyPI and PyPI
-        * remove `plot_example.py` 
+        * remove `plot_example.py`
         * add autolabel rule for `fix` and `linting`
         * fix linting rules
         * add zenodo release to `CITAITON.cff`
@@ -127,19 +128,19 @@ Upcoming Release (25.01)
         * changes to UMA-16 microphone array arrangement
 
     * Internal:
-        * formatting and linting with ruff 
-        * introduce hatch 
+        * formatting and linting with ruff
+        * introduce hatch
         * measure test coverage
-        * replace `zenodo.json` by `CITATION.cff` 
-        * Bugfixes CI 
-        * update LICENSE 
-        * adds code of conduct 
+        * replace `zenodo.json` by `CITATION.cff`
+        * Bugfixes CI
+        * update LICENSE
+        * adds code of conduct
         * allow workflow dispatch for testing on different branches using GitHub
-        * improve documentation 
+        * improve documentation
         * refine package structure
             * move test directory outside of the source directory
             * remove outdated submodules `fileimport` and `nidaqimport`
-            * introduce new submodule `acoular/tools` 
+            * introduce new submodule `acoular/tools`
 
 
 
@@ -147,18 +148,18 @@ Upcoming Release (25.01)
 ------------
     * Improve test coverage for :class:`~acoular.fbeamform.BeamformerCMF`
     * Changes to :class:`~acoular.fbeamform.BeamformerSODIX`:
-        * correction of wrong cost-function 
+        * correction of wrong cost-function
         * speedups through the use of `numpy.einsum_path` together with `numpy.einsum`
         * changed start value `pgtol` for the optimization with `scipy.optimize.fmin_l_bfgs_b` solver
     * Bugfixes:
         * fixes unrecognized sector arguments in :class:`~acoular.tools.MetricEvaluator`
         * handles version-dependent default values for `normalize` attribute in sklearn solvers (relevant for :class:`~acoular.fbeamform.BeamformerCMF` )
         * fixes bug in :class:`~acoular.fbeamform.BeamformerOrth`: assigned strongest source at grid index 0 when instead of `eva_list` the trait `n` was given
-        * fixes broken :class:`~acoular.tprocess.SpatialInterpolator` 
-        * minor bugfix for single microphone transfer functions calculated with :class:`~acoular.fbeamform.SteeringVector` 
+        * fixes broken :class:`~acoular.tprocess.SpatialInterpolator`
+        * minor bugfix for single microphone transfer functions calculated with :class:`~acoular.fbeamform.SteeringVector`
         * fixes broken `NNLS` method in :class:`~acoular.fbeamform.BeamformerCMF` (wrong keyword argument `normalize`)
     * Internal:
-        * new GitHub workflow for CI of the documentation 
+        * new GitHub workflow for CI of the documentation
         * added Zenodo metadata file
         * changes to author name in `pyproject.toml`
 
@@ -168,7 +169,7 @@ Upcoming Release (25.01)
     * New class :class:`~acoular.tools.MetricEvaluator` to evaluate the performance of source mapping methods according to Herold and Sarradj (2017)
     * New class :class:`~acoular.sources.PointSourceConvolve` to blockwise convolve an arbitrary source signal with a spatial room impulse response
     * All filter classes derived from :class:`~acoular.tprocess.Filter` use SOS filters now
-    * No more version restrictions for scikit-learn 
+    * No more version restrictions for scikit-learn
     * Speedups for numba jitted functions by enforcing C-contiguous arguments and the efficient use SIMD processor instructions
     * :class:`~acoular.fbeamform.BeamformerOrth` now reimplements orthogonal deconvolution to be even faster and has a slightly different interface
     * Simple benchmark suite to compare the performance of Acoular core routines on different computers
@@ -193,8 +194,8 @@ Upcoming Release (25.01)
     * :class:`~acoular.microphones.MicGeom` now has an aperture trait
     * Tests are improved
     * Bugfixes:
-        * broken numpy.int import 
-        * one off bug in :class:`~acoular.grids.LineGrid` 
+        * broken numpy.int import
+        * one off bug in :class:`~acoular.grids.LineGrid`
 
 
 22.3
@@ -206,7 +207,7 @@ Upcoming Release (25.01)
     * Speedups:
         * time domain beamformers and CleanT deconvolution now share a common core codebase and all do blockwise processing
     * Bugfixes:
-        * broken digest in :class:`~acoular.grids.RectGrid3D` repaired 
+        * broken digest in :class:`~acoular.grids.RectGrid3D` repaired
         * :class:`~acoular.tbeamform.BeamformerCleant` and derived classes now never miss samples
 
 
@@ -217,7 +218,7 @@ Upcoming Release (25.01)
     * New class :class:`~acoular.signals.FiltWNoiseGenerator`
     * New classes :class:`~acoular.sources.SphericalHarmonicSource`, :class:`~acoular.sources.Linesource`, :class:`~acoular.sources.MovingPointSourceDipole`, :class:`~acoular.sources.MovingLineSource`
     * New class :class:`~acoular.tprocess.TimeConvolve`
-    * Speedups: 
+    * Speedups:
         * CSM works now in parallel and is faster
         * frequency domain beamformers are abaout 30% faster
         * time domain beamformers and CLEAN-T is now about 10 x faster
@@ -228,7 +229,7 @@ Upcoming Release (25.01)
 
 20.10
 ------------
-    
+
     * Supports Python 3.6, 3.7, 3.8
     * New base classes for time signal processing: :class:`~acoular.tprocess.Filter`, :class:`~acoular.tprocess.FilterBank`
         * New filter classes: :class:`~acoular.tprocess.TimeExpAverage`, :class:`~acoular.tprocess.FiltFreqWeight`, :class:`~acoular.tprocess.OctaveFilterBank`
@@ -262,7 +263,7 @@ Upcoming Release (25.01)
 19.11
 ------------
     * Adds new classes for handling rotating data, including detection of trigger signals and interpolation of sensor data for virtual array emulation (:class:`~acoular.tprocess.Trigger`, :class:`~acoular.tprocess.AngleTracker`, :class:`~acoular.tprocess.SpatialInterpolator`, :class:`~acoular.tprocess.SpatialInterpolatorRotation`, :class:`~acoular.tprocess.SpatialInterpolatorConstantRotation`)
-    * Introduces new :class:`~acoular.process.SampleSplitter` class, which allows distribution of data streams 
+    * Introduces new :class:`~acoular.process.SampleSplitter` class, which allows distribution of data streams
     * Adds new (global) caching options for more flexible cache file handling (e.g. never cache results, always cache, cache read-only). See :class:`~acoular.configuration.config` for information on how to use this.
     * User can choose whether to use h5py or pytables package for handling hdf files. See :class:`~acoular.configuration.config` for information on how to use this.
     * Change: BeamformerGIB behaviour (not calculating sources with eigenvalue of zero)
@@ -273,7 +274,7 @@ Upcoming Release (25.01)
 
 19.08
 ------------
-    
+
     * Supports Python 3.5, 3.6, 3.7
     * This will be the last version to officially support Python 2.7
     * Cache and data directories are now always created in current directory (Linux and Windows)
@@ -287,11 +288,11 @@ Upcoming Release (25.01)
 
 19.02
 ------------
-    
+
     * Adds support for Python 3.7
     * Introduces new :class:`~acoular.fbeamform.SteeringVector` class (see :doc:`../get_started/index` and `../examples/index` for usage). With this, some of the Beamformer and PointSource traits are deprecated and should no longer be used. While the current version is intended to be fully compatible with older scripts, deprecation warnings will be raised if necessary.
     * Introduces optional use of reference distance for SPL evaluation (current default: reference position at (x,y,z)=(0,0,0) )
-    * Introduces some basic Unit tests to evaluate the beamformer results 
+    * Introduces some basic Unit tests to evaluate the beamformer results
     * Bugfix: CLEAN algorithm now uses correct PSFs
     * some minor Bugfixes
 
@@ -305,11 +306,11 @@ Upcoming Release (25.01)
     * Floating point precision of CSM, PSF and beamformer customizable (default: float64) -- affects cache file size
     * PowerSpectra class now includes EigSpectra functionality (EigSpectra still callable for backwards compatibility)
     * Inverse methods: unit of sound pressure for internal calculation customizable (default: nPa) for better numeric stability with sklearn solvers. Still returns all values in Pa.
-    * Bugfix: BeamformerFunctional works now with steering vector formulation II (inverse) and III (true level) which produced incorrect results in the past. 
+    * Bugfix: BeamformerFunctional works now with steering vector formulation II (inverse) and III (true level) which produced incorrect results in the past.
     * Bugfix: BeamformerFunctional can only be called when the diagonal of the CSM is included
     * Bugfix: Corrected calculation of PSF for steering vector formulation IV
     * Bugfix: Behaviour of normalizing PSF at assumed source location (psf=1) is removed
-    
+
 
 
 
@@ -317,10 +318,6 @@ Upcoming Release (25.01)
 17.11
 ------------
 
-    * Added support for Python 3.4, 3.5 and 3.6 
+    * Added support for Python 3.4, 3.5 and 3.6
     * Implementation of fast/parallelized code now with Numba (instead of C++ and SciPy.weave)
     * cross spectral matrix (CSM) orientation changed (was transposed in earlier versions). Please do not use the cache files from earlier versions in version 17.11!
-        
-
-
-

--- a/docs/source/news/index.rst
+++ b/docs/source/news/index.rst
@@ -7,21 +7,21 @@ Upcoming Release (25.01)
     **New features:**
         * consistently use `file` as an attribute to specify a filename (instead of `from_file` or `name`)
         * adds new function :meth:`~acoular.tools.helper.c_air` to calculate the speed of sound from temperature and humidity
-        * :class:`acoular.calib.Calib` can now be used as as a separte processing block
+        * :class:`~acoular.calib.Calib` can now be used as a separate processing block
         * enable varying block buffer sizes for :class:`~acoular.process.SampleSplitter`
 
         * Replaces `HasPrivateTraits` with `HasStrictTraits` and `ABCHasStrictTraits` for better implementation of ABCs.
         * Allow Path objects to specify the caching and time data directory via `acoular.Config`
 
     **Bugfixes**
-        * pass missing `max_iter` as an argument to `LassoLarsCV` in :class:`acoular.fbeamform.BeamformerGIB` (otherwise, LassoLarsCV runs up to 500 iterations)
-        * fix broken pylops solvers in :class:`acoular.fbeamform.BeamformerCMF`
+        * pass missing `max_iter` as an argument to `LassoLarsCV` in :class:`acoular.fbeamform.BeamformerGIB` (otherwise, `LassoLarsCV` runs up to 500 iterations)
+        * fix broken `pylops` solvers in :class:`~acoular.fbeamform.BeamformerCMF`
         * fixes negative values in source maps obtained with the solvers `LassoLars`, `LassoLarsCV` and `LassoLarsBIC`
-        * fix use of Trait() factory and replace by Enum, Instance, Map, Union
+        * fix use of `Trait()` factory and replace by `Enum`, `Instance`, `Map`, `Union`
 
     **Documentation**
         * adds guide on how to submit a pull request
-        * adds intersphinx extension to cross-link documentation from other projects
+        * adds `intersphinx` extension to cross-link documentation from other projects
 
     **Tests**
         * tests now consequently use `pytest` framework instead of `unittest`
@@ -29,13 +29,13 @@ Upcoming Release (25.01)
         * increases coverage to 76 %
         * introduces snapshot / regression testing for all :class:`~acoular.base.Generator`, :class:`~acoular.fbeamform.BeamformerBase`, :class:`~acoular.environments.FlowField`, and :class:`~acoular.environments.Environment` derived classes (results in new snapshot data of size 1.1MB (see `tests/regression/_regtest_output`)
         * use `pytest-cases` to separate parameters from tests (cases are located under `tests/cases`)
-        * full coverage of `sdinput.py` module through the use of `pytest-mock` (mocks the behavior of an InputStream object, which cannot be used for CI due to missing audio interfaces)
+        * full coverage of `sdinput.py` module through the use of `pytest-mock` (mocks the behavior of an `InputStream` object, which cannot be used for CI due to missing audio interfaces)
         * linting and formatting for tests directory
-        * refactor :class:`~acoular.h5cache.HDF5Cache` class due to a bug encountered with the new tests (acoular now can handle changing caching directories during a session. Previously, only the basename was observed which caused problems with changing cache directories)
+        * refactor :class:`~acoular.h5cache.HDF5Cache` class due to a bug encountered with the new tests (`acoular` now can handle changing caching directories during a session. Previously, only the basename was observed which caused problems with changing cache directories)
         * tests now log the 10 slowest test runs
-        * adds `profile` options to hatch test environment to profile test run via `hatch run tests:profile` and save a graphviz chart as SVG file
+        * adds `profile` options to hatch test environment to profile test run via `hatch run tests:profile` and save a `graphviz` chart as SVG file
         * test AIAA benchmark classes with the benchmark data
-        * test `aperture`, `center`, `export_mpos`` functions in :class:`~acoular.microphones.MicGeom`
+        * test `aperture`, `center`, `export_mpos` functions in :class:`~acoular.microphones.MicGeom`
         * fix a typo in `AngleTracker` that lead to a property being incorrectly accessed
         * exclude jited functions from test coverage report
         * treat warnings as errors in tests
@@ -43,14 +43,14 @@ Upcoming Release (25.01)
 
     **Internal**
         * adds a pull request template
-        * dynamically set the version in the pyproject.toml file (from version.py)
+        * dynamically set the version in the `pyproject.toml` file (from `version.py`)
         * activates maximum line length enforcement of 120 and 100 for comments and docstrings
         * adds CI workflow for inspecting regression test outputs
         * adds action that automatically assigns a team member to newly opened pull requests
         * `depends_on` now only accepts a list of strings
         * removes deprecated traits ending with version 25.01
         * include doctests in coverage report
-        * no longer add docs label if news/index.rst is updated
+        * no longer add docs label if `news/index.rst` is updated
 
 24.10
 ----------------

--- a/tests/cases/test_environments_cases.py
+++ b/tests/cases/test_environments_cases.py
@@ -39,9 +39,6 @@ class Flows:
     def case_default(self, flow):
         return flow()
 
-    def case_FlowField(self):
-        return ac.FlowField()
-
     def case_SlotJet(self):
         return ac.SlotJet(v0=70.0, origin=(-0.7, 0, 0.7))
 

--- a/tests/unittests/test_classes.py
+++ b/tests/unittests/test_classes.py
@@ -17,15 +17,16 @@ all_hastraits_classes = get_all_classes(hastraits_only=True)
 
 
 def create_instance(acoular_cls):
-    if isabstract(acoular_cls):
-        pytest.skip(f'{acoular_cls.__name__} is an abstract base class')
-    if acoular_cls.__name__ in ['H5CacheFileH5py', 'H5CacheFileTables', 'H5FileH5py', 'H5FileTables']:
-        return acoular_cls(tempfile.mkstemp()[1] + '.h5', 'w')
-    if acoular_cls.__name__ in ['LockedGenerator', 'LazyBfResult']:
-        return acoular_cls(None)
-    if acoular_cls.__name__ == 'Polygon':
-        return acoular_cls([0], [1])
-    return acoular_cls()
+    with warnings.catch_warnings(action='ignore'):
+        if isabstract(acoular_cls):
+            pytest.skip(f'{acoular_cls.__name__} is an abstract base class.')
+        if acoular_cls.__name__ in ['H5CacheFileH5py', 'H5CacheFileTables', 'H5FileH5py', 'H5FileTables']:
+            return acoular_cls(tempfile.mkstemp()[1] + '.h5', 'w')
+        if acoular_cls.__name__ in ['LockedGenerator', 'LazyBfResult']:
+            return acoular_cls(None)
+        if acoular_cls.__name__ == 'Polygon':
+            return acoular_cls([0], [1])
+        return acoular_cls()
 
 
 @pytest.mark.parametrize('acoular_cls', all_classes)
@@ -39,33 +40,31 @@ def test_instancing(acoular_cls):
 @pytest.mark.parametrize('acoular_cls', all_hastraits_classes)
 def test_set_traits(acoular_cls):
     """Test that important traits can be set."""
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore', category=DeprecationWarning)
-        if hasattr(acoular_cls, 'class_traits') and 'digest' in acoular_cls.class_traits():
-            do = acoular_cls.class_traits()['digest'].depends_on
-            if do:
-                obj = create_instance(acoular_cls)
-                digest = obj.digest
-                assert digest is not None
-                assert digest != ''
-                for k in do:
-                    if k in acoular_cls.class_trait_names():
-                        tr = acoular_cls.class_traits()[k]
-                        # handling different Trait types
-                        # TODO: use hypothesis based setattr #noqa: TD002, TD003, FIX002
-                        if tr.is_trait_type(Int):
-                            setattr(obj, k, 1)
-                        elif tr.is_trait_type(Float):
-                            setattr(obj, k, 0.1)
-                        elif tr.is_trait_type(Bool):
-                            setattr(obj, k, False)
-                        elif tr.is_trait_type(Range):
-                            low = tr.handler._low
-                            high = tr.handler._high
-                            setattr(obj, k, (high + low) / 2)
-                        elif tr.is_trait_type(TraitEnum) or tr.is_trait_type(Enum):
-                            v = tr.handler.values
-                            setattr(obj, k, v[len(v) // 2])
+    if hasattr(acoular_cls, 'class_traits') and 'digest' in acoular_cls.class_traits():
+        do = acoular_cls.class_traits()['digest'].depends_on
+        if do:
+            obj = create_instance(acoular_cls)
+            digest = obj.digest
+            assert digest is not None
+            assert digest != ''
+            for k in do:
+                if k in acoular_cls.class_trait_names():
+                    tr = acoular_cls.class_traits()[k]
+                    # handling different Trait types
+                    # TODO: use hypothesis based setattr #noqa: TD002, TD003, FIX002
+                    if tr.is_trait_type(Int):
+                        setattr(obj, k, 1)
+                    elif tr.is_trait_type(Float):
+                        setattr(obj, k, 0.1)
+                    elif tr.is_trait_type(Bool):
+                        setattr(obj, k, False)
+                    elif tr.is_trait_type(Range):
+                        low = tr.handler._low
+                        high = tr.handler._high
+                        setattr(obj, k, (high + low) / 2)
+                    elif tr.is_trait_type(TraitEnum) or tr.is_trait_type(Enum):
+                        v = tr.handler.values
+                        setattr(obj, k, v[len(v) // 2])
 
 
 @pytest.mark.parametrize('acoular_cls', all_hastraits_classes)

--- a/tests/unittests/test_classes.py
+++ b/tests/unittests/test_classes.py
@@ -82,12 +82,10 @@ def test_trait_dependencies(acoular_cls):
         assert len(objtname := tname.split('.')) < 3, 'Trait dependency too deep.'
         # recurse if trait depends on a trait of another object
         if len(objtname) == 2:
-            # skip if trait is Any
-            if obj.trait(objtname[0]).trait_type != Any:
-                # instantiate the trait
-                obj = create_instance(obj.trait(objtname[0]).trait_type.klass)
-                tname = objtname[1]
-                check_or_unpack(obj, tname, toplevel=False)
+            # instantiate the trait
+            obj = create_instance(obj.trait(objtname[0]).trait_type.klass)
+            tname = objtname[1]
+            check_or_unpack(obj, tname, toplevel=False)
         else:
             # deal with traits extended name definition by stripping trailing '[]'
             # https://docs.enthought.com/traits/traits_user_manual/listening.html#semantics

--- a/tests/unittests/test_classes.py
+++ b/tests/unittests/test_classes.py
@@ -52,7 +52,8 @@ def test_set_traits(acoular_cls):
                 if k in acoular_cls.class_trait_names():
                     tr = acoular_cls.class_traits()[k]
                     # handling different Trait types
-                    # TODO: use hypothesis based setattr #noqa: TD002, TD003, FIX002
+                    # TODO(adku1173): use hypothesis based setattr
+                    # 421
                     if tr.is_trait_type(Int):
                         setattr(obj, k, 1)
                     elif tr.is_trait_type(Float):
@@ -68,7 +69,10 @@ def test_set_traits(acoular_cls):
                         setattr(obj, k, v[len(v) // 2])
 
 
-# TODO: #418, #419, #420 remove the entries when respective issue is fixed #noqa: TD002, TD003, FIX002
+# TODO(artpelling): remove the entries when respective issue is fixed
+# 418
+# 419
+# 420
 xfails = {
     'PowerSpectraImport': 'Issue #418',
     'CsmAIAABenchmark': 'Issue #418',

--- a/tests/unittests/test_classes.py
+++ b/tests/unittests/test_classes.py
@@ -8,7 +8,7 @@ import warnings
 from inspect import isabstract
 
 import pytest
-from traits.api import Any, Bool, Enum, Float, Int, Range, TraitEnum
+from traits.api import Bool, Enum, Float, Int, Range, TraitEnum
 
 from tests.utils import get_all_classes
 
@@ -67,7 +67,7 @@ def test_set_traits(acoular_cls):
                         setattr(obj, k, v[len(v) // 2])
 
 
-# TODO: remove the entries when respective issue is fixed
+# TODO: #418, #419, #420 remove the entries when respective issue is fixed #noqa: TD002, TD003, FIX002
 xfails = {
     'PowerSpectraImport': 'Issue #418',
     'CsmAIAABenchmark': 'Issue #418',
@@ -76,7 +76,7 @@ xfails = {
 }
 for c in all_hastraits_classes.copy():
     try:
-        if c.__name__ in xfails.keys():
+        if c.__name__ in xfails:
             all_hastraits_classes.remove(c)
             all_hastraits_classes.append(pytest.param(c, marks=pytest.mark.xfail(reason=xfails[c.__name__])))
     except AttributeError:

--- a/tests/unittests/test_classes.py
+++ b/tests/unittests/test_classes.py
@@ -17,7 +17,8 @@ all_hastraits_classes = get_all_classes(hastraits_only=True)
 
 
 def create_instance(acoular_cls):
-    with warnings.catch_warnings(action='ignore'):
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
         if isabstract(acoular_cls):
             pytest.skip(f'{acoular_cls.__name__} is an abstract base class.')
         if acoular_cls.__name__ in ['H5CacheFileH5py', 'H5CacheFileTables', 'H5FileH5py', 'H5FileTables']:

--- a/tests/unittests/test_classes.py
+++ b/tests/unittests/test_classes.py
@@ -67,6 +67,13 @@ def test_set_traits(acoular_cls):
                         setattr(obj, k, v[len(v) // 2])
 
 
+# TODO: remove the following block when #418 is fixed
+for c in all_hastraits_classes.copy():
+    if c.__name__ in ('PowerSpectraImport', 'CsmAIAABenchmark'):
+        all_hastraits_classes.remove(c)
+        all_hastraits_classes.append(pytest.param(c, marks=pytest.mark.xfail(reason='issue #418')))
+
+
 @pytest.mark.parametrize('acoular_cls', all_hastraits_classes)
 def test_trait_dependencies(acoular_cls):
     """Assert that a property that is depended on depends on something."""

--- a/tests/unittests/test_classes.py
+++ b/tests/unittests/test_classes.py
@@ -90,7 +90,7 @@ for c in all_hastraits_classes.copy():
 
 @pytest.mark.parametrize('acoular_cls', all_hastraits_classes)
 def test_trait_dependencies(acoular_cls):
-    """Assert that a property that is depended on depends on something."""
+    """Assert that any property, that is being depended on, itself depends on something."""
 
     def check_or_unpack(obj, tname, toplevel=True):
         assert len(objtname := tname.split('.')) < 3, 'Trait dependency too deep.'

--- a/tests/unittests/test_classes.py
+++ b/tests/unittests/test_classes.py
@@ -67,11 +67,20 @@ def test_set_traits(acoular_cls):
                         setattr(obj, k, v[len(v) // 2])
 
 
-# TODO: remove the following block when #418 is fixed
+# TODO: remove the entries when respective issue is fixed
+xfails = {
+    'PowerSpectraImport': 'Issue #418',
+    'CsmAIAABenchmark': 'Issue #418',
+    'MergeGrid': 'Issue #419',
+    'SpatialInterpolator': 'Issue #420',
+}
 for c in all_hastraits_classes.copy():
-    if c.__name__ in ('PowerSpectraImport', 'CsmAIAABenchmark'):
-        all_hastraits_classes.remove(c)
-        all_hastraits_classes.append(pytest.param(c, marks=pytest.mark.xfail(reason='issue #418')))
+    try:
+        if c.__name__ in xfails.keys():
+            all_hastraits_classes.remove(c)
+            all_hastraits_classes.append(pytest.param(c, marks=pytest.mark.xfail(reason=xfails[c.__name__])))
+    except AttributeError:
+        pass
 
 
 @pytest.mark.parametrize('acoular_cls', all_hastraits_classes)

--- a/tests/unittests/test_classes.py
+++ b/tests/unittests/test_classes.py
@@ -71,12 +71,10 @@ def test_set_traits(acoular_cls):
 
 # TODO(artpelling): remove the entries when respective issue is fixed
 # 418
-# 419
 # 420
 xfails = {
     'PowerSpectraImport': 'Issue #418',
     'CsmAIAABenchmark': 'Issue #418',
-    'MergeGrid': 'Issue #419',
     'SpatialInterpolator': 'Issue #420',
 }
 for c in all_hastraits_classes.copy():
@@ -90,7 +88,7 @@ for c in all_hastraits_classes.copy():
 
 @pytest.mark.parametrize('acoular_cls', all_hastraits_classes)
 def test_trait_dependencies(acoular_cls):
-    """Assert that any property, that is being depended on, itself depends on something."""
+    """Assert that any property that is being depended on itself depends on something."""
 
     def check_or_unpack(obj, tname, toplevel=True):
         assert len(objtname := tname.split('.')) < 3, 'Trait dependency too deep.'

--- a/tests/unittests/test_classes.py
+++ b/tests/unittests/test_classes.py
@@ -18,7 +18,7 @@ all_hastraits_classes = get_all_classes(hastraits_only=True)
 
 def create_instance(acoular_cls):
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=DeprecationWarning)
+        warnings.filterwarnings('ignore', category=DeprecationWarning)
         if isabstract(acoular_cls):
             pytest.skip(f'{acoular_cls.__name__} is an abstract base class.')
         if acoular_cls.__name__ in ['H5CacheFileH5py', 'H5CacheFileTables', 'H5FileH5py', 'H5FileTables']:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,6 +3,7 @@ import inspect
 import pkgutil
 import warnings
 from pathlib import Path
+from traits.api import HasTraits
 
 import acoular as ac
 import numpy as np
@@ -10,14 +11,15 @@ import pytest
 from pytest_cases import get_case_id
 
 
-def get_all_classes():
+def get_all_classes(hastraits_only=False):
     classes = []
     package = importlib.import_module('acoular')
     for module_info in pkgutil.walk_packages(package.__path__, package.__name__ + '.'):
         module = importlib.import_module(module_info.name)
         for _, cls in inspect.getmembers(module, inspect.isclass):
             if cls.__module__ == module_info.name:  # ensure class is defined in the current module
-                classes.append(cls)
+                if not hastraits_only or issubclass(cls, HasTraits):
+                    classes.append(cls)
     return classes
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -26,10 +26,9 @@ def get_all_classes(hastraits_only=False):
 def get_subclasses(cls, include_abstract=False):
     classes = []
     for _, subcls in inspect.getmembers(ac):
-        if all([
-                inspect.isclass(subcls) and issubclass(subcls, cls),
-                not inspect.isabstract(subcls) or include_abstract
-        ]):
+        if all(
+            [inspect.isclass(subcls) and issubclass(subcls, cls), not inspect.isabstract(subcls) or include_abstract]
+        ):
             classes.append(subcls)
     return classes
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,12 +3,12 @@ import inspect
 import pkgutil
 import warnings
 from pathlib import Path
-from traits.api import HasTraits
 
 import acoular as ac
 import numpy as np
 import pytest
 from pytest_cases import get_case_id
+from traits.api import HasTraits
 
 
 def get_all_classes(hastraits_only=False):
@@ -17,9 +17,9 @@ def get_all_classes(hastraits_only=False):
     for module_info in pkgutil.walk_packages(package.__path__, package.__name__ + '.'):
         module = importlib.import_module(module_info.name)
         for _, cls in inspect.getmembers(module, inspect.isclass):
-            if cls.__module__ == module_info.name:  # ensure class is defined in the current module
-                if not hastraits_only or issubclass(cls, HasTraits):
-                    classes.append(cls)
+            # ensure class is defined in the current module
+            if cls.__module__ == module_info.name and (not hastraits_only or issubclass(cls, HasTraits)):
+                classes.append(cls)
     return classes
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -15,19 +15,20 @@ def get_all_classes():
     package = importlib.import_module('acoular')
     for module_info in pkgutil.walk_packages(package.__path__, package.__name__ + '.'):
         module = importlib.import_module(module_info.name)
-        for _, obj in inspect.getmembers(module, inspect.isclass):
-            if obj.__module__ == module_info.name:  # ensure class is defined in the current module
-                classes.append(obj)
+        for _, cls in inspect.getmembers(module, inspect.isclass):
+            if cls.__module__ == module_info.name:  # ensure class is defined in the current module
+                classes.append(cls)
     return classes
 
 
 def get_subclasses(cls, include_abstract=False):
     classes = []
-    for _, obj in inspect.getmembers(ac):
-        if inspect.isclass(obj) and issubclass(obj, cls):
-            if inspect.isabstract(obj) and not include_abstract:
-                continue
-            classes.append(obj)
+    for _, subcls in inspect.getmembers(ac):
+        if all([
+                inspect.isclass(subcls) and issubclass(subcls, cls),
+                not inspect.isabstract(subcls) or include_abstract
+        ]):
+            classes.append(subcls)
     return classes
 
 


### PR DESCRIPTION
### Description
<!-- Please provide a detailed description of your changes. Include any relevant context or background. -->
- Adds a test that recursively ensures that any `Property` trait that is referenced by `depends_on` in another `Property` trait `depends_on` something.
- ~Refactors the `depends_on` keys to always be a list of strings. Before, `'a, b, c'` was used alongside `['a', 'b', 'c']` but now the latter is needed for the test to pass. Both are equivalent as per the [traits docs](https://docs.enthought.com/traits/traits_user_manual/listening.html#semantics).~
- Updates the `ruff` linting rules to deactivate `FIXME`
- Removes `noqa:TDXXX` and fixes them (proper `# TODO:` formatting)
- Turns `FlowField` into an abstract class, removes `FlowField.v` method, and removes `FlowField` from regression tests.
- New Issues #418, #419, #420 for remaining bugs the new test found

### Reference issue
<!-- If this pull request closes a issue, please denote it like: Closes #141. -->
Closes #359 

### Checklist
<!-- Please make sure that your pull request checks all the boxes. -->
- [x] I have read the [Contributing](https://www.acoular.org/contributing/index.html) section.
- [x] My branch is up-to-date with the *master* branch of the [Acoular repository](https://github.com/acoular/acoular).
- [x] My changes fulfill the [Code Quality](https://www.acoular.org/contributing/quality.html) standards.
- [x] I have updated the [What's new](https://www.acoular.org/news/index.html) section the the [documentation](https://github.com/acoular/acoular/blob/master/docs/source/news/index.rst) explaining my changes.
- [x] I have appended myself to the [CITATION.cff](https://github.com/acoular/acoular/blob/master/CITATION.cff) file.
