### PR TITLE
Refactor `depends_on` dependencies

### DIFF
--- a/acoular/fbeamform.py
+++ b/acoular/fbeamform.py
@@ -202,7 +202,7 @@ class SteeringVector(HasStrictTraits):
     # internal identifier, use for inverse methods, excluding steering vector type
     inv_digest = Property(depends_on=['env.digest', 'grid.digest', 'mics.digest', '_ref'])
 
-    @property_depends_on('grid.digest, env.digest, _ref')
+    @property_depends_on(['grid.digest', 'env.digest', '_ref'])
     def _get_r0(self):
         if isscalar(self.ref):
             if self.ref > 0:
@@ -210,7 +210,7 @@ class SteeringVector(HasStrictTraits):
             return self.env._r(self.grid.pos())
         return self.env._r(self.grid.pos, self.ref[:, newaxis])
 
-    @property_depends_on('grid.digest, mics.digest, env.digest')
+    @property_depends_on(['grid.digest', 'mics.digest', 'env.digest'])
     def _get_rm(self):
         return atleast_2d(self.env._r(self.grid.pos, self.mics.pos))
 
@@ -533,7 +533,7 @@ class BeamformerBase(HasStrictTraits):
             msg = f'{num_channels:d} channels do not fit {self.steer.mics.num_mics:d} mics'
             raise ValueError(msg)
 
-    @property_depends_on('digest')
+    @property_depends_on(['digest'])
     def _get_result(self):
         """Implements the :attr:`result` getter routine.
         The beamforming result is either loaded or calculated.
@@ -973,7 +973,7 @@ class BeamformerEig(BeamformerBase):
     def _get_digest(self):
         return digest(self)
 
-    @property_depends_on('steer.mics, n')
+    @property_depends_on(['steer.mics', 'n'])
     def _get_na(self):
         na = self.n
         nm = self.steer.mics.num_mics

--- a/acoular/fprocess.py
+++ b/acoular/fprocess.py
@@ -58,10 +58,10 @@ class RFFT(BaseSpectra, SpectraOut):
     block_size = Property()
 
     #: Number of frequencies in the output.
-    num_freqs = Property(depends_on='_block_size')
+    num_freqs = Property(depends_on=['_block_size'])
 
     #: Number of snapshots in the output.
-    num_samples = Property(depends_on='source.num_samples, _block_size')
+    num_samples = Property(depends_on=['source.num_samples', '_block_size'])
 
     #: 1-D array of FFT sample frequencies.
     freqs = Property()
@@ -168,7 +168,7 @@ class IRFFT(TimeOut):
     precision = Enum('float64', 'float32', desc='precision of the time signal after the ifft')
 
     #: Number of time samples in the output.
-    num_samples = Property(depends_on='source.num_samples, source._block_size')
+    num_samples = Property(depends_on=['source.num_samples', 'source._block_size'])
 
     # internal time signal buffer to handle arbitrary output block sizes
     _buffer = CArray(desc='signal buffer')
@@ -306,7 +306,7 @@ class CrossPowerSpectra(AutoPowerSpectra):
     #: :attr:`num_channels` is :math:`n^2`, where :math:`n` is the number of
     #: channels in the input. If :attr:`calc_mode` is 'upper', then
     #: :attr:`num_channels` is :math:`n + n(n-1)/2`.
-    num_channels = Property(depends_on='source.num_channels')
+    num_channels = Property(depends_on=['source.num_channels'])
 
     # internal identifier
     digest = Property(depends_on=['source.digest', 'precision', 'scaling', 'single_sided', 'calc_mode'])

--- a/acoular/grids.py
+++ b/acoular/grids.py
@@ -286,18 +286,18 @@ class Grid(ABCHasStrictTraits):
 
     # 'digest' is a placeholder for other properties in derived classes,
     # necessary to trigger the depends on mechanism
-    @property_depends_on('digest')
+    @property_depends_on(['digest'])
     @abstractmethod
     def _get_size(self):
         """Returns the number of grid points."""
 
     # 'digest' is a placeholder for other properties in derived classes
-    @property_depends_on('digest')
+    @property_depends_on(['digest'])
     @abstractmethod
     def _get_shape(self):
         """Returns the shape of the grid as a Tuple."""
 
-    @property_depends_on('digest')
+    @property_depends_on(['digest'])
     @abstractmethod
     def _get_pos(self):
         """Returns the grid positions as (3, size) array of floats."""
@@ -364,22 +364,22 @@ class RectGrid(Grid):
         depends_on=['x_min', 'x_max', 'y_min', 'y_max', 'z', 'increment'],
     )
 
-    @property_depends_on('nxsteps, nysteps')
+    @property_depends_on(['nxsteps', 'nysteps'])
     def _get_size(self):
         return self.nxsteps * self.nysteps
 
-    @property_depends_on('nxsteps, nysteps')
+    @property_depends_on(['nxsteps', 'nysteps'])
     def _get_shape(self):
         return (self.nxsteps, self.nysteps)
 
-    @property_depends_on('x_min, x_max, increment')
+    @property_depends_on(['x_min', 'x_max', 'increment'])
     def _get_nxsteps(self):
         i = abs(self.increment)
         if i != 0:
             return int(round((abs(self.x_max - self.x_min) + i) / i))
         return 1
 
-    @property_depends_on('y_min, y_max, increment')
+    @property_depends_on(['y_min', 'y_max', 'increment'])
     def _get_nysteps(self):
         i = abs(self.increment)
         if i != 0:
@@ -390,7 +390,7 @@ class RectGrid(Grid):
     def _get_digest(self):
         return digest(self)
 
-    @property_depends_on('x_min, x_max, y_min, y_max, increment')
+    @property_depends_on(['x_min', 'x_max', 'y_min', 'y_max', 'increment'])
     def _get_pos(self):
         """Calculates grid co-ordinates.
 
@@ -579,29 +579,29 @@ class RectGrid3D(RectGrid):
         depends_on=['x_min', 'x_max', 'y_min', 'y_max', 'z_min', 'z_max', '_increment'],
     )
 
-    @property_depends_on('nxsteps, nysteps, nzsteps')
+    @property_depends_on(['nxsteps', 'nysteps', 'nzsteps'])
     def _get_size(self):
         return self.nxsteps * self.nysteps * self.nzsteps
 
-    @property_depends_on('nxsteps, nysteps, nzsteps')
+    @property_depends_on(['nxsteps', 'nysteps', 'nzsteps'])
     def _get_shape(self):
         return (self.nxsteps, self.nysteps, self.nzsteps)
 
-    @property_depends_on('x_min, x_max, _increment')
+    @property_depends_on(['x_min', 'x_max', '_increment'])
     def _get_nxsteps(self):
         i = abs(self.increment) if isscalar(self.increment) else abs(self.increment[0])
         if i != 0:
             return int(round((abs(self.x_max - self.x_min) + i) / i))
         return 1
 
-    @property_depends_on('y_min, y_max, _increment')
+    @property_depends_on(['y_min', 'y_max', '_increment'])
     def _get_nysteps(self):
         i = abs(self.increment) if isscalar(self.increment) else abs(self.increment[1])
         if i != 0:
             return int(round((abs(self.y_max - self.y_min) + i) / i))
         return 1
 
-    @property_depends_on('z_min, z_max, _increment')
+    @property_depends_on(['z_min', 'z_max', '_increment'])
     def _get_nzsteps(self):
         i = abs(self.increment) if isscalar(self.increment) else abs(self.increment[2])
         if i != 0:
@@ -702,9 +702,7 @@ class ImportGrid(Grid):
     subgrids = CArray(desc='names of subgrids for each point')
 
     # internal identifier
-    digest = Property(
-        depends_on=['gpos_file'],
-    )
+    digest = Property(depends_on=['gpos_file'])
 
     @cached_property
     def _get_digest(self):
@@ -712,16 +710,16 @@ class ImportGrid(Grid):
 
     # 'digest' is a placeholder for other properties in derived classes,
     # necessary to trigger the depends on mechanism
-    @property_depends_on('gpos_file')
+    @property_depends_on(['gpos_file'])
     def _get_size(self):
         return self.pos.shape[-1]
 
     # 'digest' is a placeholder for other properties in derived classes
-    @property_depends_on('gpos_file')
+    @property_depends_on(['gpos_file'])
     def _get_shape(self):
         return (self.pos.shape[-1],)
 
-    @property_depends_on('gpos_file')
+    @property_depends_on(['gpos_file'])
     def _get_pos(self):
         return self.gpos_file
 
@@ -775,16 +773,16 @@ class LineGrid(Grid):
 
     # 'digest' is a placeholder for other properties in derived classes,
     # necessary to trigger the depends on mechanism
-    @property_depends_on('numpoints')
+    @property_depends_on(['numpoints'])
     def _get_size(self):
         return self.pos.shape[-1]
 
     # 'digest' is a placeholder for other properties in derived classes
-    @property_depends_on('numpoints')
+    @property_depends_on(['numpoints'])
     def _get_shape(self):
         return self.pos.shape[-1]
 
-    @property_depends_on('numpoints,length,direction,loc')
+    @property_depends_on(['numpoints', 'length', 'direction', 'loc'])
     def _get_pos(self):
         dist = self.length / (self.numpoints - 1)
         loc = array(self.loc, dtype=float).reshape((3, 1))
@@ -826,23 +824,23 @@ class MergeGrid(Grid):
 
     # 'digest' is a placeholder for other properties in derived classes,
     # necessary to trigger the depends on mechanism
-    @property_depends_on('digest')
+    @property_depends_on(['digest'])
     def _get_size(self):
         return self.pos.shape[-1]
 
     # 'digest' is a placeholder for other properties in derived classes
-    @property_depends_on('digest')
+    @property_depends_on(['digest'])
     def _get_shape(self):
         return self.pos.shape[-1]
 
-    @property_depends_on('digest')
+    @property_depends_on(['digest'])
     def _get_subgrids(self):
         subgrids = zeros((1, 0), dtype=str)
         for grid in self.grids:
             subgrids = append(subgrids, tile(grid.__class__.__name__ + grid.digest, grid.size))
         return subgrids[:, newaxis].T
 
-    @property_depends_on('digest')
+    @property_depends_on(['digest'])
     def _get_pos(self):
         bpos = zeros((3, 0))
         # subgrids = zeros((1,0))

--- a/acoular/process.py
+++ b/acoular/process.py
@@ -97,11 +97,11 @@ class Average(InOut):
     num_per_average = Int(64, desc='number of samples/snapshots to average over')
 
     #: Sampling frequency of the output signal, is set automatically.
-    sample_freq = Property(depends_on='source.sample_freq, num_per_average')
+    sample_freq = Property(depends_on=['source.sample_freq', 'num_per_average'])
 
     #: Number of samples (time domain) or snapshots (frequency domain) of the output signal.
     #: Is set automatically.
-    num_samples = Property(depends_on='source.num_samples, num_per_average')
+    num_samples = Property(depends_on=['source.num_samples', 'num_per_average'])
 
     # internal identifier
     digest = Property(depends_on=['source.digest', '__class__', 'num_per_average'])
@@ -179,7 +179,7 @@ class Cache(InOut):
     """
 
     # basename for cache
-    basename = Property(depends_on='digest')
+    basename = Property(depends_on=['digest'])
 
     # hdf5 cache file
     h5f = Instance(H5CacheFileBase, transient=True)

--- a/acoular/signals.py
+++ b/acoular/signals.py
@@ -60,7 +60,7 @@ class SignalGenerator(ABCHasStrictTraits):
     num_samples = CLong
 
     # internal identifier
-    digest = Property
+    digest = Property(depends_on=['rms', 'sample_freq', 'numsamples'])
 
     @abstractmethod
     def _get_digest(self):
@@ -85,7 +85,6 @@ class SignalGenerator(ABCHasStrictTraits):
         -------
         array of floats
             The resulting signal of length `factor` * :attr:`numsamples`.
-
         """
         return resample(self.signal(), factor * self.numsamples)
 
@@ -99,9 +98,7 @@ class WNoiseGenerator(SignalGenerator):
     seed = Int(0, desc='random seed value')
 
     # internal identifier
-    digest = Property(
-        depends_on=['rms', 'numsamples', 'sample_freq', 'seed', '__class__'],
-    )
+    digest = Property(depends_on=['rms', 'numsamples', 'sample_freq', 'seed', '__class__'])
 
     @cached_property
     def _get_digest(self):
@@ -114,7 +111,6 @@ class WNoiseGenerator(SignalGenerator):
         -------
         Array of floats
             The resulting signal as an array of length :attr:`~SignalGenerator.numsamples`.
-
         """
         rnd_gen = RandomState(self.seed)
         return self.rms * rnd_gen.standard_normal(self.num_samples)
@@ -143,9 +139,7 @@ class PNoiseGenerator(SignalGenerator):
     depth = Int(16, desc='octave depth')
 
     # internal identifier
-    digest = Property(
-        depends_on=['rms', 'numsamples', 'sample_freq', 'seed', 'depth', '__class__'],
-    )
+    digest = Property(depends_on=['rms', 'numsamples', 'sample_freq', 'seed', 'depth', '__class__'])
 
     @cached_property
     def _get_digest(self):
@@ -217,7 +211,6 @@ class FiltWNoiseGenerator(WNoiseGenerator):
         -------
         Array of floats
             The resulting signal as an array of length :attr:`~SignalGenerator.numsamples`.
-
         """
         rnd_gen = RandomState(self.seed)
         ma = self.handle_empty_coefficients(self.ma)
@@ -273,9 +266,7 @@ class SineGenerator(SignalGenerator):
         self._amp = amp
 
     # internal identifier
-    digest = Property(
-        depends_on=['_amp', 'numsamples', 'sample_freq', 'freq', 'phase', '__class__'],
-    )
+    digest = Property(depends_on=['_amp', 'numsamples', 'sample_freq', 'freq', 'phase', '__class__'])
 
     @cached_property
     def _get_digest(self):
@@ -288,7 +279,6 @@ class SineGenerator(SignalGenerator):
         -------
         array of floats
             The resulting signal as an array of length :attr:`~SignalGenerator.numsamples`.
-
         """
         t = arange(self.num_samples, dtype=float) / self.sample_freq
         return self.amplitude * sin(2 * pi * self.freq * t + self.phase)
@@ -308,7 +298,6 @@ class GenericSignalGenerator(SignalGenerator):
     >>> data = np.random.rand(1000, 1)
     >>> ts = TimeSamples(data=data, sample_freq=51200)
     >>> sig = GenericSignalGenerator(source=ts)
-
     """
 
     #: Data source; :class:`~acoular.base.SamplesGenerator` or derived object.

--- a/acoular/sources.py
+++ b/acoular/sources.py
@@ -230,10 +230,7 @@ class TimeSamples(SamplesGenerator):
     file = File(filter=['*.h5'], exists=True, desc='name of data file')
 
     #: Basename of the .h5 file with data, is set automatically.
-    basename = Property(
-        depends_on='file',  # filter=['*.h5'],
-        desc='basename of data file',
-    )
+    basename = Property(depends_on=['file'], desc='basename of data file')
 
     #: Calibration data, instance of :class:`~acoular.calib.Calib` class, optional .
     calib = Instance(Calib, desc='Calibration data')

--- a/acoular/spectra.py
+++ b/acoular/spectra.py
@@ -236,7 +236,7 @@ class PowerSpectra(BaseSpectra):
     indices = Property(desc='index range')
 
     #: Name of the cache file without extension, readonly.
-    basename = Property(depends_on='_source.digest', desc='basename for cache file')
+    basename = Property(depends_on=['_source.digest'], desc='basename for cache file')
 
     #: The cross spectral matrix,
     #: (number of frequencies, num_channels, num_channels) array of complex;
@@ -272,11 +272,11 @@ class PowerSpectra(BaseSpectra):
         warn(msg, DeprecationWarning, stacklevel=2)
         self._calib = calib
 
-    @property_depends_on('_source.num_samples, block_size, overlap')
+    @property_depends_on(['_source.num_samples', 'block_size', 'overlap'])
     def _get_num_blocks(self):
         return self.overlap_ * self._source.num_samples / self.block_size - self.overlap_ + 1
 
-    @property_depends_on('_source.sample_freq, block_size, ind_low, ind_high')
+    @property_depends_on(['_source.sample_freq', 'block_size', 'ind_low', 'ind_high'])
     def _get_freq_range(self):
         fftfreq = self.fftfreq()
         if fftfreq is not None:
@@ -290,7 +290,7 @@ class PowerSpectra(BaseSpectra):
         self._freqlc = freq_range[0]
         self._freqhc = freq_range[1]
 
-    @property_depends_on('_source.sample_freq, block_size, _ind_low, _freqlc')
+    @property_depends_on(['_source.sample_freq', 'block_size', '_ind_low', '_freqlc'])
     def _get_ind_low(self):
         fftfreq = self.fftfreq()
         if fftfreq is not None:
@@ -299,7 +299,7 @@ class PowerSpectra(BaseSpectra):
             return searchsorted(fftfreq[:-1], self._freqlc)
         return None
 
-    @property_depends_on('_source.sample_freq, block_size, _ind_high, _freqhc')
+    @property_depends_on(['_source.sample_freq', 'block_size', '_ind_high', '_freqhc'])
     def _get_ind_high(self):
         fftfreq = self.fftfreq()
         if fftfreq is not None:
@@ -337,7 +337,7 @@ class PowerSpectra(BaseSpectra):
     def _get_source(self):
         return self._source
 
-    @property_depends_on('block_size, ind_low, ind_high')
+    @property_depends_on(['block_size', 'ind_low', 'ind_high'])
     def _get_indices(self):
         fftfreq = self.fftfreq()
         if fftfreq is not None:
@@ -470,7 +470,7 @@ class PowerSpectra(BaseSpectra):
             self.h5f.flush()
         return ac
 
-    @property_depends_on('digest')
+    @property_depends_on(['digest'])
     def _get_csm(self):
         """Main work is done here:
         Cross spectral matrix is either loaded from cache file or
@@ -481,7 +481,7 @@ class PowerSpectra(BaseSpectra):
             return self.calc_csm()
         return self._get_filecache('csm')
 
-    @property_depends_on('digest')
+    @property_depends_on(['digest'])
     def _get_eva(self):
         """Eigenvalues of cross spectral matrix are either loaded from cache file or
         calculated and then additionally stored into cache.
@@ -490,7 +490,7 @@ class PowerSpectra(BaseSpectra):
             return self.calc_eva()
         return self._get_filecache('eva')
 
-    @property_depends_on('digest')
+    @property_depends_on(['digest'])
     def _get_eve(self):
         """Eigenvectors of cross spectral matrix are either loaded from cache file or
         calculated and then additionally stored into cache.
@@ -687,14 +687,10 @@ class PowerSpectraImport(PowerSpectra):
     _ind_high = Union(None, Int, desc='index of highest frequency line')
 
     # internal identifier
-    digest = Property(
-        depends_on=[
-            '_csmsum',
-        ],
-    )
+    digest = Property(depends_on=['_csmsum'])
 
     #: Name of the cache file without extension, readonly.
-    basename = Property(depends_on='digest', desc='basename for cache file')
+    basename = Property(depends_on=['digest'], desc='basename for cache file')
 
     # csm shadow trait, only for internal use.
     _csm = CArray()
@@ -723,14 +719,14 @@ class PowerSpectraImport(PowerSpectra):
         self._csmsum = real(self._csm).sum() + (imag(self._csm) ** 2).sum()  # to trigger new digest creation
         self._csm = csm
 
-    @property_depends_on('digest')
+    @property_depends_on(['digest'])
     def _get_eva(self):
         """Eigenvalues of cross spectral matrix are either loaded from cache file or
         calculated and then additionally stored into cache.
         """
         return self.calc_eva()
 
-    @property_depends_on('digest')
+    @property_depends_on(['digest'])
     def _get_eve(self):
         """Eigenvectors of cross spectral matrix are either loaded from cache file or
         calculated and then additionally stored into cache.

--- a/acoular/tools/aiaa.py
+++ b/acoular/tools/aiaa.py
@@ -93,7 +93,7 @@ class CsmAIAABenchmark(PowerSpectraImport):
 
     #: Basename of the .h5 file with data, is set automatically.
     basename = Property(
-        depends_on='file',
+        depends_on=['file'],
         desc='basename of data file',
     )
 
@@ -130,7 +130,7 @@ class CsmAIAABenchmark(PowerSpectraImport):
         except IndexError:
             return range(0)
 
-    @property_depends_on('digest')
+    @property_depends_on(['digest'])
     def _get_num_channels(self):
         try:
             attrs = self.h5f.get_data_by_reference('MetaData/ArrayAttributes')
@@ -138,7 +138,7 @@ class CsmAIAABenchmark(PowerSpectraImport):
         except IndexError:
             return 0
 
-    @property_depends_on('digest')
+    @property_depends_on(['digest'])
     def _get_csm(self):
         """Loads cross spectral matrix from file."""
         csmre = self.h5f.get_data_by_reference('/CsmData/csmReal')[:].transpose((2, 0, 1))

--- a/acoular/tprocess.py
+++ b/acoular/tprocess.py
@@ -157,7 +157,7 @@ class MaskedTimeOut(TimeOut):
     )
 
     # Name of the cache file without extension, readonly.
-    basename = Property(depends_on='source.digest', desc='basename for cache file')
+    basename = Property(depends_on=['source.digest'], desc='basename for cache file')
 
     # internal identifier
     digest = Property(depends_on=['source.digest', 'start', 'stop', 'invalid_channels'])
@@ -541,13 +541,13 @@ class AngleTracker(MaskedTimeOut):
     start_angle = Float(0, desc='rotation angle for trigger position')
 
     # revolutions per minute for each sample, read-only
-    rpm = Property(depends_on='digest', desc='revolutions per minute for each sample')
+    rpm = Property(depends_on=['digest'], desc='revolutions per minute for each sample')
 
     # average revolutions per minute, read-only
-    average_rpm = Property(depends_on='digest', desc='average revolutions per minute')
+    average_rpm = Property(depends_on=['digest'], desc='average revolutions per minute')
 
     # rotation angle in radians for each sample, read-only
-    angle = Property(depends_on='digest', desc='rotation angle for each sample')
+    angle = Property(depends_on=['digest'], desc='rotation angle for each sample')
 
     # Internal flag to determine whether rpm and angle calculation has been processed,
     # prevents recalculation
@@ -1780,7 +1780,7 @@ class WriteWAV(TimeOut):
     file = File(filter=['*.wav'], desc='name of wave file')
 
     # Basename for cache, readonly.
-    basename = Property(depends_on='digest')
+    basename = Property(depends_on=['digest'])
 
     # Channel(s) to save. List can only contain one or two channels.
     channels = ListInt(desc='channel to save')

--- a/acoular/trajectory.py
+++ b/acoular/trajectory.py
@@ -43,19 +43,17 @@ class Trajectory(HasStrictTraits):
     tck = Property()
 
     # internal identifier
-    digest = Property(
-        depends_on=['points[]'],
-    )
+    digest = Property(depends_on=['points[]'])
 
     @cached_property
     def _get_digest(self):
         return digest(self)
 
-    @property_depends_on('points[]')
+    @property_depends_on(['points[]'])
     def _get_interval(self):
         return sort(list(self.points.keys()))[r_[0, -1]]
 
-    @property_depends_on('points[]')
+    @property_depends_on(['points[]'])
     def _get_tck(self):
         t = sort(list(self.points.keys()))
         xp = array([self.points[i] for i in t]).T

--- a/docs/source/news/index.rst
+++ b/docs/source/news/index.rst
@@ -42,6 +42,7 @@ Upcoming Release (25.01)
         * activates maximum line length enforcement of 120 and 100 for comments and docstrings
         * adds CI workflow for inspecting regression test outputs
         * adds action that automatically assigns a team member to newly opened pull requests
+        * `depends_on` now only accepts a list of strings
 
 24.10
 ----------------


### PR DESCRIPTION
<!-- 
Thank you so much for contributing a pull request! Please ensure
that your pull request satisfies the checklist before submitting:
https://www.acoular.org/contributing/checklist.html

If you are part the of Acoular development team, please make sure to
select a label for this pull request on the sidebar to the right.

Check out the milestones here: https://github.com/acoular/acoular/milestones

Again, thanks for contributing!
-->

### Description
<!-- Please provide a detailed description of your changes. Include any relevant context or background. -->
- Refactors the `depends_on` keys to always be a list of strings. Before, `'a, b, c'` was used alongside `['a', 'b', 'c']`. Both are equivalent as per the [traits docs](https://docs.enthought.com/traits/traits_user_manual/listening.html#semantics).

### Reference issue
<!-- If this pull request closes a issue, please denote it like: Closes #141. -->

### Checklist
<!-- Please make sure that your pull request checks all the boxes. -->
- [x] I have read the [Contributing](https://www.acoular.org/contributing/index.html) section.
- [x] My branch is up-to-date with the *master* branch of the [Acoular repository](https://github.com/acoular/acoular).
- [x] My changes fulfill the [Code Quality](https://www.acoular.org/contributing/quality.html) standards.
- [x] I have updated the [What's new](https://www.acoular.org/news/index.html) section the the [documentation](https://github.com/acoular/acoular/blob/master/docs/source/news/index.rst) explaining my changes.
- [x] I have appended myself to the [CITATION.cff](https://github.com/acoular/acoular/blob/master/CITATION.cff) file.
