### PR TITLE
Intersphinx

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-
+import sys
 import acoular
 from sphinx_gallery.sorting import ExplicitOrder
 
@@ -31,6 +31,7 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.inheritance_diagram',
     'sphinx.ext.autosummary',
+    'sphinx.ext.intersphinx',
     'sphinxcontrib.bibtex',
     'numpydoc',
     'matplotlib.sphinxext.plot_directive',
@@ -171,3 +172,12 @@ bibtex_default_style = 'unsrt'
 plot_include_source = True
 plot_html_show_source_link = False
 plot_html_show_formats = False
+
+#%% 
+# intersphinx extension settings
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/{.major}".format(sys.version_info), None),
+    "numpy": ("https://numpy.org/doc/stable", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
+}

--- a/docs/source/news/index.rst
+++ b/docs/source/news/index.rst
@@ -21,6 +21,7 @@ Upcoming Release (25.01)
 
     **Documentation**
         * adds guide on how to submit a pull request
+        * adds intersphinx extension to cross-link documentation from other projects
 
     **Tests**
         * tests now consequently use `pytest` framework instead of `unittest`


### PR DESCRIPTION
adds intersphinx connection for Python, SciPy and NumPy documentation.

One can now use for example 
```
:class:`numpy.ndarray`
``` 
for cross-linking, which then renders as:

![image](https://github.com/user-attachments/assets/132f8df4-21f3-47db-9916-d6919a1967a7)
