### PR TITLE
Prevents numpy from premature loading

### DIFF
--- a/acoular/configuration.py
+++ b/acoular/configuration.py
@@ -15,7 +15,7 @@ import sys
 from os import environ, mkdir, path
 from warnings import warn
 
-from traits.api import File
+# WARNING: DO NOT ADD ANY IMPORTS HERE THAT MIGHT IMPORT NUMPY
 
 # When numpy is using OpenBLAS then it runs with OPENBLAS_NUM_THREADS which may lead to
 # overcommittment when called from within numba jitted function that run on
@@ -52,11 +52,11 @@ if 'numpy' in sys.modules:
             stacklevel=2,
         )
 else:
-    # numpy is not loaded
+    # numpy is not loaded, make sure that OpenBLAS runs single threaded
     environ['OPENBLAS_NUM_THREADS'] = '1'
 
 # this loads numpy, so we have to defer loading until OpenBLAS check is done
-from traits.api import Bool, Enum, HasStrictTraits, Property, cached_property
+from traits.api import Bool, Enum, HasStrictTraits, File, Property, cached_property  # noqa: I001
 
 
 class Config(HasStrictTraits):


### PR DESCRIPTION
### Description
Prevents premature loading of Numpy, so that Acoular has the chance to run in parallel 

### Reference issue
<!-- If this pull request closes a issue, please denote it like: Closes #141. -->
Closes #412

### Checklist
<!-- Please make sure that your pull request checks all the boxes. -->
- [x] I have read the [Contributing](https://www.acoular.org/contributing/index.html) section.
- [x] My branch is up-to-date with the *master* branch of the [Acoular repository](https://github.com/acoular/acoular).
- [x] My changes fulfill the [Code Quality](https://www.acoular.org/contributing/quality.html) standards.
- [-] I have updated the [What's new](https://www.acoular.org/news/index.html) section the the [documentation](https://github.com/acoular/acoular/blob/master/docs/source/news/index.rst) explaining my changes.
- [-] I have appended myself to the [CITATION.cff](https://github.com/acoular/acoular/blob/master/CITATION.cff) file.
