### PR TITLE
DAGA2025 Umbrella MicGeom

### DIFF
--- a/acoular/xml/umbracoular.xml
+++ b/acoular/xml/umbracoular.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?><MicArray name="umbracoular">
+   <!-- DAGA2025 Acoular demo array made from an umbrella (setup with 8 stereo-nodes -->
+   <!-- form two tight circles with radii of 42 and 41 cm and a z offset of 1.5 cm) -->
+  <pos Name="Point 1" x="0.42" y="0.0" z="0.0"/>
+  <pos Name="Point 2" x="0.41" y="0.0" z="1.5"/>
+  <pos Name="Point 3" x="0.30" y="0.30" z="0.0"/>
+  <pos Name="Point 4" x="0.29" y="0.29" z="1.5"/>
+  <pos Name="Point 5" x="0.0" y="0.42" z="0.0"/>
+  <pos Name="Point 6" x="0.0" y="0.41" z="1.5"/>
+  <pos Name="Point 7" x="-0.30" y="0.30" z="0.0"/>
+  <pos Name="Point 8" x="-0.29" y="0.29" z="1.5"/>
+  <pos Name="Point 9" x="-0.42" y="0.0" z="0.0"/>
+  <pos Name="Point 10" x="-0.41" y="0.0" z="1.5"/>
+  <pos Name="Point 11" x="-0.30" y="-0.30" z="0.0"/>
+  <pos Name="Point 12" x="-0.29" y="-0.29" z="1.5"/>
+  <pos Name="Point 13" x="0.0" y="-0.42" z="0.0"/>
+  <pos Name="Point 14" x="0.0" y="-0.41" z="1.5"/>
+  <pos Name="Point 15" x="0.30" y="-0.30" z="0.0"/>
+  <pos Name="Point 16" x="0.29" y="-0.29" z="1.5"/>
+</MicArray>


### PR DESCRIPTION
### Description
Improvised array setup for DAGA2025 using an umbrella (see image). This PR proposes a "rough" mic geometry `umbracoular.xml`.

![image](https://github.com/user-attachments/assets/0130f749-e78c-41f7-aa5b-828a04f8510d)


### Checklist
<!-- Please make sure that your pull request checks all the boxes. -->
- [x] I have read the [Contributing](https://www.acoular.org/contributing/index.html) section.
- [x] My branch is up-to-date with the *master* branch of the [Acoular repository](https://github.com/acoular/acoular).
- [x] My changes fulfill the [Code Quality](https://www.acoular.org/contributing/quality.html) standards.
- [ ] I have updated the [What's new](https://www.acoular.org/news/index.html) section the the [documentation](https://github.com/acoular/acoular/blob/master/docs/source/news/index.rst) explaining my changes.
- [x] I have appended myself to the [CITATION.cff](https://github.com/acoular/acoular/blob/master/CITATION.cff) file.
