### PR TITLE
fixes import error

### DIFF
--- a/acoular/aiaa/aiaa.py
+++ b/acoular/aiaa/aiaa.py
@@ -170,7 +170,7 @@ class MicAIAABenchmark(MicGeom):
     file = File(filter=['*.h5'], exists=True, desc='name of the h5 file containing the microphone geometry')
 
     @on_trait_change('file')
-    def import_mpos(self):
+    def _import_mpos(self):
         """Import the microphone positions from .h5 file.
         Called when :attr:`basename` changes.
         """

--- a/acoular/version.py
+++ b/acoular/version.py
@@ -4,5 +4,5 @@
 
 # separate file to find out about version without importing the acoular lib
 __author__ = 'Acoular Development Team'
-__date__ = '12 March 2025'
-__version__ = '25.03'
+__date__ = '18 March 2025'
+__version__ = '25.03.post1'


### PR DESCRIPTION
Base class MicGeom uses `_import_mpos`. This method should be overwritten by the AIAA benchmark class instead of `import_mpos`