### PR TITLE
remove conda verify

### DIFF
--- a/.github/actions/setup-conda/action.yml
+++ b/.github/actions/setup-conda/action.yml
@@ -22,9 +22,6 @@ runs:
     - name: Install conda build
       shell: bash
       run: conda install -n base conda-build # Install conda-build in the base env
-    - name: Install conda-verify
-      shell: bash
-      run: conda install -n base conda-verify
     - name: Install anaconda-client
       shell: bash
       run: |


### PR DESCRIPTION
Removes the installation step for `conda-verify` from the GitHub Actions workflow for setting up Conda. This change simplifies the workflow by eliminating an unused dependency.
