### PR TITLE
block-wise processing in MovingPointSource

### DIFF
--- a/acoular/sources.py
+++ b/acoular/sources.py
@@ -1173,7 +1173,7 @@ class MovingPointSource(PointSource):
         c0 = self.env.c
         tr = self.trajectory
         n = self.num_samples
-        while n>0:
+        while n > 0:
             eps = ones_like(t)  # init discrepancy in time
             te = t.copy()  # init emission time = receiving time
             j = 0
@@ -1207,6 +1207,7 @@ class MovingPointSource(PointSource):
                     yield out[:n]
                 break
             n -= num
+
 
 class PointSourceDipole(PointSource):
     """

--- a/acoular/sources.py
+++ b/acoular/sources.py
@@ -1172,7 +1172,8 @@ class MovingPointSource(PointSource):
         epslim = 0.1 / self.up / self.sample_freq
         c0 = self.env.c
         tr = self.trajectory
-        while True:
+        n = self.num_samples
+        while n>0:
             eps = ones_like(t)  # init discrepancy in time
             te = t.copy()  # init emission time = receiving time
             j = 0
@@ -1195,7 +1196,7 @@ class MovingPointSource(PointSource):
             try:
                 ind = array(0.5 + ind * self.up, dtype=int64)
                 out = (signal[ind] / rm).T
-                yield out
+                yield out[:n]
             except IndexError:  # last incomplete frame
                 signal_length = signal.shape[0]
                 # Filter ind to exclude columns containing values greater than signal_length
@@ -1203,9 +1204,9 @@ class MovingPointSource(PointSource):
                 out = (signal[ind[:, mask]] / rm[:, mask]).T
                 # If out is not empty, yield it
                 if out.size > 0:
-                    yield out
+                    yield out[:n]
                 break
-
+            n -= num
 
 class PointSourceDipole(PointSource):
     """

--- a/acoular/sources.py
+++ b/acoular/sources.py
@@ -45,6 +45,7 @@ from numpy import (
     mod,
     newaxis,
     ones,
+    ones_like,
     pi,
     real,
     repeat,
@@ -1164,46 +1165,46 @@ class MovingPointSource(PointSource):
         # from the end of the calculated signal.
 
         signal = self.signal.usignal(self.up)
-        out = empty((num, self.num_channels))
         # shortcuts and initial values
-        m = self.mics
-        t = self.start * ones(m.num_mics)
-        i = 0
+        num_mics = self.num_channels
+        mpos = self.mics.pos[:, :, newaxis]
+        t = self.start + ones(num_mics)[:, newaxis] * arange(num) / self.sample_freq
         epslim = 0.1 / self.up / self.sample_freq
         c0 = self.env.c
         tr = self.trajectory
-        n = self.num_samples
-        while n:
-            n -= 1
-            eps = ones(m.num_mics)
+        while True:
+            eps = ones_like(t)  # init discrepancy in time
             te = t.copy()  # init emission time = receiving time
             j = 0
             # Newton-Rhapson iteration
             while abs(eps).max() > epslim and j < 100:
-                loc = array(tr.location(te))
-                rm = loc - m.pos  # distance vectors to microphones
+                loc = array(tr.location(te.flatten())).reshape((3, num_mics, -1))
+                rm = loc - mpos  # distance vectors to microphones
                 rm = sqrt((rm * rm).sum(0))  # absolute distance
                 loc /= sqrt((loc * loc).sum(0))  # distance unit vector
-                der = array(tr.location(te, der=1))
+                der = array(tr.location(te.flatten(), der=1)).reshape((3, num_mics, -1))
                 Mr = (der * loc).sum(0) / c0  # radial Mach number
-                eps = (te + rm / c0 - t) / (1 + Mr)  # discrepancy in time
+                eps[:] = (te + rm / c0 - t) / (1 + Mr)  # discrepancy in time
                 te -= eps
                 j += 1  # iteration count
-            t += 1.0 / self.sample_freq
+            t += num / self.sample_freq
             # emission time relative to start time
             ind = (te - self.start_t + self.start) * self.sample_freq
             if self.conv_amp:
                 rm *= (1 - Mr) ** 2
             try:
-                out[i] = signal[array(0.5 + ind * self.up, dtype=int64)] / rm
-                i += 1
-                if i == num:
+                ind = array(0.5 + ind * self.up, dtype=int64)
+                out = (signal[ind] / rm).T
+                yield out
+            except IndexError:  # last incomplete frame
+                signal_length = signal.shape[0]
+                # Filter ind to exclude columns containing values greater than signal_length
+                mask = (ind < signal_length).all(axis=0)
+                out = (signal[ind[:, mask]] / rm[:, mask]).T
+                # If out is not empty, yield it
+                if out.size > 0:
                     yield out
-                    i = 0
-            except IndexError:  # if no more samples available from the source
                 break
-        if i > 0:  # if there are still samples to yield
-            yield out[:i]
 
 
 class PointSourceDipole(PointSource):

--- a/docs/source/news/index.rst
+++ b/docs/source/news/index.rst
@@ -4,7 +4,8 @@ What's new
 
 Upcoming Release
 ------------------------
-
+    **Internal**
+        * introduces speedup for :class:'~acoular.sources.MovingPointSource' by using block-wise processing
 
 25.04
 ------------------------


### PR DESCRIPTION
### Description
Simulation of microphone signals in the presence of moving sources is very slow. This PR introduces block-wise processing in `MovingPointSource`, resulting in approx. 100-fold speedup over the old sample-wise processing.

### Checklist
<!-- Please make sure that your pull request checks all the boxes. -->
- [x] I have read the [Contributing](https://www.acoular.org/contributing/index.html) section.
- [x] My branch is up-to-date with the *master* branch of the [Acoular repository](https://github.com/acoular/acoular).
- [x] My changes fulfill the [Code Quality](https://www.acoular.org/contributing/quality.html) standards.
- [x] I have updated the [What's new](https://www.acoular.org/news/index.html) section the the [documentation](https://github.com/acoular/acoular/blob/master/docs/source/news/index.rst) explaining my changes.
- [ ] I have appended myself to the [CITATION.cff](https://github.com/acoular/acoular/blob/master/CITATION.cff) file.
