### PR TITLE
fix deprecation issue for output parameters of scipy solver

### DIFF
--- a/acoular/fbeamform.py
+++ b/acoular/fbeamform.py
@@ -1872,10 +1872,8 @@ class BeamformerCMF(BeamformerBase):
                     factr=10000000.0,
                     pgtol=1e-05,
                     epsilon=1e-08,
-                    iprint=-1,
                     maxfun=15000,
                     maxiter=self.n_iter,
-                    disp=None,
                     callback=None,
                     maxls=20,
                 )
@@ -2042,10 +2040,8 @@ class BeamformerSODIX(BeamformerBase):
                         factr=100.0,
                         pgtol=1e-12,
                         epsilon=1e-08,
-                        iprint=-1,
                         maxfun=1500000,
                         maxiter=self.n_iter,
-                        disp=-1,
                         callback=None,
                         maxls=20,
                     )

--- a/docs/source/news/index.rst
+++ b/docs/source/news/index.rst
@@ -6,6 +6,7 @@ Upcoming Release
 ------------------------
     **Internal**
         * introduces speedup for :class:'~acoular.sources.MovingPointSource' by using block-wise processing
+        * fixes deprecation issue for output parameters of scipy.optimize.fmin_l_bfgs_b solver
 
 25.04
 ------------------------


### PR DESCRIPTION
Fixes deprecation issue for output parameters of scipy.optimize.fmin_l_bfgs_b solver (py >=3.11)

<!-- 
Thank you so much for contributing a pull request! Please ensure
that your pull request satisfies the checklist before submitting:
https://www.acoular.org/contributing/checklist.html

If you are part the of Acoular development team, please make sure to
select a label for this pull request on the sidebar to the right.

Check out the milestones here: https://github.com/acoular/acoular/milestones

Again, thanks for contributing!
-->

### Description
<!-- Please provide a detailed description of your changes. Include any relevant context or background. -->

### Reference issue
<!-- If this pull request closes a issue, please denote it like: Closes #141. -->

### Checklist
<!-- Please make sure that your pull request checks all the boxes. -->
- [ ] I have read the [Contributing](https://www.acoular.org/contributing/index.html) section.
- [ ] My branch is up-to-date with the *master* branch of the [Acoular repository](https://github.com/acoular/acoular).
- [ ] My changes fulfill the [Code Quality](https://www.acoular.org/contributing/quality.html) standards.
- [ ] I have updated the [What's new](https://www.acoular.org/news/index.html) section the the [documentation](https://github.com/acoular/acoular/blob/master/docs/source/news/index.rst) explaining my changes.
- [ ] I have appended myself to the [CITATION.cff](https://github.com/acoular/acoular/blob/master/CITATION.cff) file.
