### PR TITLE
exclude scipy 1.16

### DIFF
--- a/docs/source/news/index.rst
+++ b/docs/source/news/index.rst
@@ -6,6 +6,7 @@ Upcoming Release
 ------------------------
     **Internal**
         * introduces speedup for :class:'~acoular.sources.MovingPointSource' by using block-wise processing
+        * excludes `scipy` version 1.16 from the dependencies due to bug affecting the `scipy.signal.tf2sos` function
 
 25.04
 ------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,10 @@ classifiers = [
 dependencies = [
     "numpy",
     "numba",
-    "scipy>=1.1.0",
+    "scipy >= 1.1.0, != 1.16.*", # scipy 1.16 has a bug in signal that causes issues with Acoular
     "scikit-learn",
     "tables",
-    "traits>=6.0",
+    "traits >= 6.0",
 ]
 maintainers = [
     {name = "Adam Kujawski", email = "adam.kujawski@tu-berlin.de"},


### PR DESCRIPTION
### Description
this PR excludes scipy 1.16 from the dependencies as it contains a bug affecting `scipy.signal.tf2sos` , see https://github.com/scipy/scipy/issues/23221

### Checklist
<!-- Please make sure that your pull request checks all the boxes. -->
- [x] I have read the [Contributing](https://www.acoular.org/contributing/index.html) section.
- [x] My branch is up-to-date with the *master* branch of the [Acoular repository](https://github.com/acoular/acoular).
- [x] My changes fulfill the [Code Quality](https://www.acoular.org/contributing/quality.html) standards.
- [x] I have updated the [What's new](https://www.acoular.org/news/index.html) section the the [documentation](https://github.com/acoular/acoular/blob/master/docs/source/news/index.rst) explaining my changes.
- [x] I have appended myself to the [CITATION.cff](https://github.com/acoular/acoular/blob/master/CITATION.cff) file.
