### PR TITLE
remove unused import

### DIFF
--- a/docs/source/gen_rst.py
+++ b/docs/source/gen_rst.py
@@ -33,7 +33,6 @@ except ImportError:
     from io import StringIO
     import pickle
     import urllib.request
-    import urllib.error
     import urllib.parse
     from urllib.error import HTTPError, URLError
 

--- a/examples/wind_tunnel_examples/example_airfoil_in_open_jet_cmf.py
+++ b/examples/wind_tunnel_examples/example_airfoil_in_open_jet_cmf.py
@@ -11,7 +11,7 @@ Uses measured data in file example_data.h5, calibration in file example_calib.xm
 microphone geometry in array_56.xml (part of Acoular).
 """
 
-import urllib
+import urllib.request
 from pathlib import Path
 
 import acoular as ac

--- a/examples/wind_tunnel_examples/example_airfoil_in_open_jet_freq_domain_methods.py
+++ b/examples/wind_tunnel_examples/example_airfoil_in_open_jet_freq_domain_methods.py
@@ -12,7 +12,7 @@ microphone geometry in array_56.xml (part of Acoular).
 
 """
 
-import urllib
+import urllib.request
 from pathlib import Path
 
 import acoular as ac

--- a/examples/wind_tunnel_examples/example_airfoil_in_open_jet_steering_vectors.py
+++ b/examples/wind_tunnel_examples/example_airfoil_in_open_jet_steering_vectors.py
@@ -11,7 +11,7 @@ Uses measured data in file example_data.h5, calibration in file example_calib.xm
 microphone geometry in array_56.xml (part of Acoular).
 """
 
-import urllib
+import urllib.request
 from pathlib import Path
 
 import acoular as ac

--- a/examples/wind_tunnel_examples/example_sectors_and_integration.py
+++ b/examples/wind_tunnel_examples/example_sectors_and_integration.py
@@ -12,7 +12,7 @@ Loads the example data set, sets diffrent Sectors for intergration.
 Shows Acoular's Sector und Sound Pressure level Integration functionality.
 """
 
-import urllib
+import urllib.request
 from pathlib import Path
 
 import acoular as ac


### PR DESCRIPTION
### Description
There was no issue with `gen_rst.py` in regards to the `urllib.request` syntax. However, I found an unused import that we can remove. 
I've replaced `import urllib` with `import urllib.request` in the relevant examples. So #479 can be closed.

### Reference issue
#479 

### Checklist
<!-- Please make sure that your pull request checks all the boxes. -->
- [x] I have read the [Contributing](https://www.acoular.org/contributing/index.html) section.
- [x] My branch is up-to-date with the *master* branch of the [Acoular repository](https://github.com/acoular/acoular).
- [x] My changes fulfill the [Code Quality](https://www.acoular.org/contributing/quality.html) standards.
- [x] I have updated the [What's new](https://www.acoular.org/news/index.html) section the the [documentation](https://github.com/acoular/acoular/blob/master/docs/source/news/index.rst) explaining my changes.
- [ ] I have appended myself to the [CITATION.cff](https://github.com/acoular/acoular/blob/master/CITATION.cff) file.
