### PR TITLE
rework `WriteWAV`

### DIFF
--- a/acoular/tprocess.py
+++ b/acoular/tprocess.py
@@ -1830,7 +1830,7 @@ class WriteWAV(TimeOut):
         data = np.round(data)
         if data.min() < dmin or data.max() > dmax:
             warn(
-                f'Clipping occured in WAV export. Data type {dtype} cannot represent all values in data. \
+                f'Clipping occurred in WAV export. Data type {dtype} cannot represent all values in data. \
             Consider raising max_val.',
                 stacklevel=1,
             )

--- a/acoular/tprocess.py
+++ b/acoular/tprocess.py
@@ -1863,7 +1863,7 @@ class WriteWAV(TimeOut):
                     yield from self.source.result(num)
             else:
                 # compute maximum and remember result to avoid calling source twice
-                data = return_result(self.source, num)
+                data = return_result(self.source, num=num)
                 mx = abs(data[:, ind]).max()
 
                 def result(num):

--- a/acoular/tprocess.py
+++ b/acoular/tprocess.py
@@ -1860,7 +1860,7 @@ class WriteWAV(TimeOut):
                 mx = self.max_val
 
                 def result(num):
-                    yield self.source.result(num)
+                    yield from self.source.result(num)
             else:
                 # compute maximum and remember result to avoid calling source twice
                 data = return_result(self.source, num)

--- a/acoular/tprocess.py
+++ b/acoular/tprocess.py
@@ -38,6 +38,7 @@ from os import path
 from warnings import warn
 
 import numba as nb
+import numpy as np
 from numpy import (
     append,
     arange,
@@ -58,7 +59,6 @@ from numpy import (
     float64,
     identity,
     inf,
-    int16,
     interp,
     linspace,
     mean,
@@ -88,6 +88,7 @@ from traits.api import (
     Constant,
     Delegate,
     Dict,
+    Either,
     Enum,
     File,
     Float,
@@ -111,6 +112,7 @@ from .environments import cartToCyl, cylToCart
 from .h5files import _get_h5file_class
 from .internal import digest, ldigest
 from .microphones import MicGeom
+from .tools.helpers import return_result
 from .tools.utils import find_basename
 
 
@@ -1788,6 +1790,12 @@ class WriteWAV(TimeOut):
     # Channel(s) to save. List can only contain one or two channels.
     channels = List(int, desc='channel to save')
 
+    # Bit depth of the output file.
+    encoding = Enum('uint8', 'int16', 'int32', desc='bit depth of the output file')
+
+    # Maximum value to scale the output to. If `None`, the maximum value of the data is used.
+    max_val = Either(None, Float, desc='Maximum value to scale the output to.')
+
     # internal identifier
     digest = Property(depends_on=['source.digest', 'channels'])
 
@@ -1807,14 +1815,34 @@ class WriteWAV(TimeOut):
         )
         return find_basename(self.source)
 
-    def save(self):
-        """Saves source output to one- or multiple-channel `*.wav` file."""
+    def _type_info(self):
+        dtype = np.dtype(self.encoding)
+        info = np.iinfo(dtype)
+        return dtype, info.min, info.max, int(info.bits / 8)
+
+    def _encode(self, data):
+        """Encodes the data according to self.encoding."""
+        dtype, min_val, max_val, _ = self._type_info()
+        if dtype == np.dtype('uint8'):
+            data = (data + 1) / 2 * max_val
+        else:
+            data *= -min_val
+        return np.round(data).clip(min_val, max_val).astype(dtype).tobytes()
+
+    def result(self, num):
         nc = len(self.channels)
         if nc == 0:
             msg = 'No channels given for output.'
             raise ValueError(msg)
-        if nc > 2:
+        elif nc > 2:
             warn(f'More than two channels given for output, exported file will have {nc:d} channels', stacklevel=1)
+        if self.sample_freq.is_integer():
+            fs = self.sample_freq
+        else:
+            fs = int(round(self.sample_freq))
+            msg = f'Sample frequency {self.sample_freq} is not a whole number. Proceeding with sampling frequency {fs}.'
+            warn(msg, Warning, stacklevel=1)
+        sw = self._type_info()[3]
         if self.file == '':
             name = self.basename
             for nr in self.channels:
@@ -1822,23 +1850,36 @@ class WriteWAV(TimeOut):
             name += '.wav'
         else:
             name = self.file
+
         with wave.open(name, 'w') as wf:
             wf.setnchannels(nc)
-            wf.setsampwidth(2)
-            wf.setframerate(self.source.sample_freq)
-            wf.setnframes(self.source.num_samples)
-            mx = 0.0
+            wf.setsampwidth(sw)
+            wf.setframerate(fs)
             ind = array(self.channels)
-            for data in self.source.result(1024):
-                mx = max(abs(data[:, ind]).max(), mx)
-            scale = 0.9 * 2**15 / mx
-            for data in self.source.result(1024):
-                wf.writeframesraw(array(data[:, ind] * scale, dtype=int16).tostring())
+            if self.max_val is not None:
+                mx = self.max_val
 
-    def result(self, num):
-        msg = 'result method not implemented yet! Data from source will be passed without transformation.'
-        warn(msg, Warning, stacklevel=2)
-        yield from self.source.result(num)
+                def result(num):
+                    yield self.source.result(num)
+            else:
+                # compute maximum and remember result to avoid calling source twice
+                data = return_result(self.source, num)
+                mx = abs(data[:, ind]).max()
+
+                def result(num):
+                    for i in range(0, self.num_samples, num):
+                        yield data[i : i + num]
+
+            # write to file
+            for data in result(num):
+                frames = self._encode(data[:, ind] / mx)
+                wf.writeframes(frames)
+                yield data
+
+    def save(self):
+        """Saves source output to one- or multiple-channel `*.wav` file."""
+        for _ in self.result(1024):
+            pass
 
 
 @deprecated_alias({'name': 'file', 'numsamples_write': 'num_samples_write', 'writeflag': 'write_flag'})

--- a/docs/source/news/index.rst
+++ b/docs/source/news/index.rst
@@ -7,6 +7,7 @@ Upcoming Release
     **New features**
         * add :meth:`~acoular.grids.Grid`.export_gpos` to :class:`~acoular.grids.Grid`
         * deprecates :meth:`~acoular.grids.RectGrid.extend` method in favor of :attr:`~acoular.grids.RectGrid.extent` property
+        * reworked `WriteWAV` class that now also supports `uint8` and `int32` encoding, adds a `max_val` attribute for normalization purposes, and avoids unnecessary double calculations
 
     **Documentation**
         * generalizes data import in the airfoil examples using the :func:`~acoular.tools.helpers.get_data_file` helper function

--- a/tests/cases/test_generator_cases.py
+++ b/tests/cases/test_generator_cases.py
@@ -199,7 +199,7 @@ class Generators:
         return ac.WriteH5(source=time_data_source, file=tmp_path / 'test.h5')
 
     def case_WriteWAV(self, time_data_source, tmp_path):
-        return ac.WriteWAV(source=time_data_source, file=tmp_path / 'test.wav')
+        return ac.WriteWAV(source=time_data_source, file=tmp_path / 'test.wav', channels=[0])
 
     def case_TimeSamplesAIAABenchmark(self, aiaa_bechmark_time_data_file):
         return ac.aiaa.TimeSamplesAIAABenchmark(file=aiaa_bechmark_time_data_file)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -59,7 +59,7 @@ def get_result(obj, num):
     prevent test failure.
     See https://github.com/acoular/acoular/issues/382 for details.
     """
-    missing_result = {'WriteWAV', 'Trigger', 'SpatialInterpolator'}
+    missing_result = {'Trigger', 'SpatialInterpolator'}
     if obj.__class__.__name__ in missing_result:
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', Warning)


### PR DESCRIPTION
<!-- 
Thank you so much for contributing a pull request! Please ensure
that your pull request satisfies the checklist before submitting:
https://www.acoular.org/contributing/checklist.html

If you are part the of Acoular development team, please make sure to
select a label for this pull request on the sidebar to the right.

Check out the milestones here: https://github.com/acoular/acoular/milestones

Again, thanks for contributing!
-->

### Description
<!-- Please provide a detailed description of your changes. Include any relevant context or background. -->

- Implements `max_val` attribute that can be used to achieve consistent scaling.
- Avoids double computation of `source.result` by storing the result in the case that `max_val` is `None` and the maximum needs to be computed.
- Adds a warning, if `sample_freq` is not a whole number. Before, it was silently rounded in the `wave` module.
- Adds `encoding` attribute to allow also `uint8` and `int32` PCM formats. `uint24` would be straightforward to add in the future but I would not add it unless there is serious demand by the user base.
- now adds a `result` generator to `WriteWAV` that writes to file and passes through the data.
- removes `WriteWAV` from the blacklist in `test_result_generator`
- adds a warning if clipping occurs

### Reference issue
<!-- If this pull request closes a issue, please denote it like: Closes #141. -->
Closes #126 #478 #473 
Related #382 

### Checklist
<!-- Please make sure that your pull request checks all the boxes. -->
- [x] I have read the [Contributing](https://www.acoular.org/contributing/index.html) section.
- [x] My branch is up-to-date with the *master* branch of the [Acoular repository](https://github.com/acoular/acoular).
- [x] My changes fulfill the [Code Quality](https://www.acoular.org/contributing/quality.html) standards.
- [x] I have updated the [What's new](https://www.acoular.org/news/index.html) section the the [documentation](https://github.com/acoular/acoular/blob/master/docs/source/news/index.rst) explaining my changes.
- [ ] I have appended myself to the [CITATION.cff](https://github.com/acoular/acoular/blob/master/CITATION.cff) file.
