### PR TITLE
Move unit system sections to Note sections

### DIFF
--- a/acoular/grids.py
+++ b/acoular/grids.py
@@ -313,8 +313,8 @@ class Grid(ABCHasStrictTraits):
 
     .. _units_note_grids:
 
-    Unit System
-    -----------
+    Notes
+    -----
     The source code is agnostic to the unit of length. The positions' coordinates are assumed to be
     in meters. This is consistent with the standard :class:`~acoular.environments.Environment` class
     which uses the speed of sound at 20°C at sea level under standard atmosphere pressure in m/s.

--- a/acoular/microphones.py
+++ b/acoular/microphones.py
@@ -43,22 +43,19 @@ class MicGeom(HasStrictTraits):
     microphone array. The positions can be read from an XML file or set programmatically. Invalid
     microphones can be excluded by specifying their indices via :attr:`invalid_channels`.
 
+    .. _units_note_microphones:
+    
     Notes
     -----
     - The microphone geometry as in :attr:`total_pos` is automatically changed if the :attr:`file`
       attribute is updated.
     - Small numerical values in the computed :attr:`center` are set to zero for numerical stability.
-
-    .. _units_note_microphones:
-
-    Unit System
-    -----------
-    The source code is agnostic to the unit of length. The microphone positions' coordinates are
-    assumed to be in meters. This is consistent with the standard
-    :class:`~acoular.environments.Environment` class which uses the speed of sound at 20°C at sea
-    level under standard atmosphere pressure in m/s. If the microphone positions' coordinates are
-    provided in a unit other than meter, it is advisable to change the
-    :attr:`~acoular.environments.Environment.c` attribute to match the given unit.
+    - The source code is agnostic to the unit of length. The microphone positions' coordinates are
+      assumed to be in meters. This is consistent with the standard
+      :class:`~acoular.environments.Environment` class which uses the speed of sound at 20°C at sea
+      level under standard atmosphere pressure in m/s. If the microphone positions' coordinates are
+      provided in a unit other than meter, it is advisable to change the
+      :attr:`~acoular.environments.Environment.c` attribute to match the given unit.
 
     Examples
     --------

--- a/acoular/microphones.py
+++ b/acoular/microphones.py
@@ -144,12 +144,12 @@ class MicGeom(HasStrictTraits):
     #: Array containing the ``x, y, z`` positions of all microphones, including invalid ones, shape
     #: ``(3,`` :attr:`num_mics` ``)``. This is set automatically when :attr:`file` changes or
     #: explicitly by assigning an array of floats. All coordinates are in meters by default (see
-    #: :ref:`notes <units_note_micophones>`).
+    #: :ref:`notes <units_note_microphones>`).
     pos_total = CArray(dtype=float, shape=(3, None), desc='x, y, z position of all microphones')
 
     #: Array containing the ``x, y, z`` positions of valid microphones (i.e., excluding those in
     #: :attr:`invalid_channels`), shape ``(3,`` :attr:`num_mics` ``)``. (read-only)
-    #: All coordinates are in meters by default (see :ref:`notes <units_note>`).
+    #: All coordinates are in meters by default (see :ref:`notes <units_note_microphones>`).
     pos = Property(depends_on=['pos_total', 'invalid_channels'], desc='x, y, z position of used microphones')
 
     #: List of indices indicating microphones to be excluded from calculations and results.
@@ -264,7 +264,7 @@ class MicGeom(HasStrictTraits):
         - This method only exports the positions of the valid microphones (those not listed in
           :attr:`invalid_channels`).
         - All coordinates (x, y, z) are exported in meters by default (see
-          :ref:`notes <units_note_micophones>`).
+          :ref:`notes <units_note_microphones>`).
         """
         filepath = Path(filename)
         basename = filepath.stem

--- a/acoular/microphones.py
+++ b/acoular/microphones.py
@@ -44,7 +44,7 @@ class MicGeom(HasStrictTraits):
     microphones can be excluded by specifying their indices via :attr:`invalid_channels`.
 
     .. _units_note_microphones:
-    
+
     Notes
     -----
     - The microphone geometry as in :attr:`total_pos` is automatically changed if the :attr:`file`

--- a/docs/source/news/index.rst
+++ b/docs/source/news/index.rst
@@ -14,6 +14,7 @@ What's new
         * changes all appearances of :meth:`~acoular.grids.RectGrid.extend` to :attr:`~acoular.grids.RectGrid.extent`
         * introduces a deprecation policy in the contributing guidelines
         * adds new docstrings to submodule :mod:`acoular.tprocess`
+        * move unit system notes to the notes sections
 
     **Tests**
         * add tests for export and load XML functionalities of :class:`~acoular.grids.Grid`


### PR DESCRIPTION
### Description
The notes about the unit system stood in custom sections. These were not recognized and caused warnings. The unit system notes are now in the Note sections.

### Checklist
<!-- Please make sure that your pull request checks all the boxes. -->
- [x] I have read the [Contributing](https://www.acoular.org/contributing/index.html) section.
- [x] My branch is up-to-date with the *master* branch of the [Acoular repository](https://github.com/acoular/acoular).
- [x] My changes fulfill the [Code Quality](https://www.acoular.org/contributing/quality.html) standards.
- [x] I have updated the [What's new](https://www.acoular.org/news/index.html) section the the [documentation](https://github.com/acoular/acoular/blob/master/docs/source/news/index.rst) explaining my changes.
- [x] I have appended myself to the [CITATION.cff](https://github.com/acoular/acoular/blob/master/CITATION.cff) file.
