### PR TITLE
fix #153

### DIFF
--- a/acoular/aiaa/aiaa.py
+++ b/acoular/aiaa/aiaa.py
@@ -116,7 +116,7 @@ class CsmAIAABenchmark(PowerSpectraImport):
         return get_file_basename(self.file)
 
     @observe('basename')
-    def load_data(self, event):  # noqa ARG002
+    def _load_data(self, event):  # noqa ARG002
         """Open the .h5 file and set attributes."""
         if self.h5f is not None:
             with contextlib.suppress(OSError):

--- a/acoular/aiaa/aiaa.py
+++ b/acoular/aiaa/aiaa.py
@@ -34,7 +34,7 @@ from traits.api import (
     Property,
     Union,
     cached_property,
-    on_trait_change,
+    observe,
     property_depends_on,
 )
 
@@ -115,8 +115,8 @@ class CsmAIAABenchmark(PowerSpectraImport):
     def _get_basename(self):
         return get_file_basename(self.file)
 
-    @on_trait_change('basename')
-    def load_data(self):
+    @observe('basename')
+    def load_data(self, event):  # noqa ARG002
         """Open the .h5 file and set attributes."""
         if self.h5f is not None:
             with contextlib.suppress(OSError):
@@ -172,8 +172,8 @@ class MicAIAABenchmark(MicGeom):
         None, File(filter=['*.h5'], exists=True), desc='name of the h5 file containing the microphone geometry'
     )
 
-    @on_trait_change('file')
-    def _import_mpos(self):
+    @observe('file')
+    def _import_mpos(self, event):  # noqa ARG002
         """
         Import the microphone positions from .h5 file.
 

--- a/acoular/calib.py
+++ b/acoular/calib.py
@@ -97,7 +97,7 @@ class Calib(InOut):
     digest = Property(depends_on=['source.digest', 'data'])
 
     @observe('data')
-    def set_num_mics(self, event):  # noqa ARG002
+    def _update_num_mics(self, event):  # noqa ARG002
         """Sets the number of microphones based on the shape of the data array."""
         self.num_mics = self.data.shape[0]
 
@@ -113,7 +113,7 @@ class Calib(InOut):
         return digest(self)
 
     @observe('file')
-    def import_data(self, event):  # noqa ARG002
+    def _import_data(self, event):  # noqa ARG002
         """Loads the calibration data from `*.xml` file ."""
         doc = xml.dom.minidom.parse(self.file)
         names = []

--- a/acoular/calib.py
+++ b/acoular/calib.py
@@ -13,7 +13,7 @@
 import xml.dom.minidom
 
 import numpy as np
-from traits.api import CArray, CInt, File, List, Property, Union, cached_property, on_trait_change
+from traits.api import CArray, CInt, File, List, Property, Union, cached_property, observe
 
 # acoular imports
 from .base import InOut, SamplesGenerator, SpectraGenerator
@@ -96,8 +96,8 @@ class Calib(InOut):
     # Internal identifier
     digest = Property(depends_on=['source.digest', 'data'])
 
-    @on_trait_change('data')
-    def set_num_mics(self):
+    @observe('data')
+    def set_num_mics(self, event):  # noqa ARG002
         """Sets the number of microphones based on the shape of the data array."""
         self.num_mics = self.data.shape[0]
 
@@ -112,8 +112,8 @@ class Calib(InOut):
     def _get_digest(self):
         return digest(self)
 
-    @on_trait_change('file')
-    def import_data(self):
+    @observe('file')
+    def import_data(self, event):  # noqa ARG002
         """Loads the calibration data from `*.xml` file ."""
         doc = xml.dom.minidom.parse(self.file)
         names = []

--- a/acoular/fbeamform.py
+++ b/acoular/fbeamform.py
@@ -59,7 +59,7 @@ from traits.api import (
     Range,
     Tuple,
     cached_property,
-    on_trait_change,
+    observe,
     property_depends_on,
 )
 from traits.trait_errors import TraitError
@@ -1330,8 +1330,8 @@ class BeamformerOrth(BeamformerBase):
     def _get_digest(self):
         return digest(self)
 
-    @on_trait_change('n')
-    def set_eva_list(self):
+    @observe('n')
+    def set_eva_list(self, event):  # noqa ARG002
         """Sets the list of eigenvalues to consider."""
         self.eva_list = np.arange(-1, -1 - self.n, -1)
 
@@ -1625,8 +1625,8 @@ class BeamformerCMF(BeamformerBase):
     def _get_digest(self):
         return digest(self)
 
-    @on_trait_change('method')
-    def _validate(self):
+    @observe('method')
+    def _validate(self, event):  # noqa ARG002
         if self.method in ['FISTA', 'Split_Bregman'] and not config.have_pylops:
             msg = (
                 'Cannot import Pylops package. No Pylops installed.'
@@ -2279,8 +2279,8 @@ class BeamformerGridlessOrth(BeamformerAdaptiveGrid):
     def _get_digest(self):
         return digest(self)
 
-    @on_trait_change('n')
-    def set_eva_list(self):
+    @observe('n')
+    def set_eva_list(self, event):  # noqa ARG002
         """Sets the list of eigenvalues to consider."""
         self.eva_list = np.arange(-1, -1 - self.n, -1)
 

--- a/acoular/fbeamform.py
+++ b/acoular/fbeamform.py
@@ -1331,7 +1331,7 @@ class BeamformerOrth(BeamformerBase):
         return digest(self)
 
     @observe('n')
-    def set_eva_list(self, event):  # noqa ARG002
+    def _update_eva_list(self, event):  # noqa ARG002
         """Sets the list of eigenvalues to consider."""
         self.eva_list = np.arange(-1, -1 - self.n, -1)
 
@@ -2280,7 +2280,7 @@ class BeamformerGridlessOrth(BeamformerAdaptiveGrid):
         return digest(self)
 
     @observe('n')
-    def set_eva_list(self, event):  # noqa ARG002
+    def _update_eva_list(self, event):  # noqa ARG002
         """Sets the list of eigenvalues to consider."""
         self.eva_list = np.arange(-1, -1 - self.n, -1)
 

--- a/acoular/grids.py
+++ b/acoular/grids.py
@@ -883,7 +883,7 @@ class ImportGrid(Grid):
         self._gpos = pos
 
     @observe('file')
-    def import_gpos(self, event):  # noqa ARG002
+    def _import_pos(self, event):  # noqa ARG002
         """
         Import the grid point locations and subgrid names from an XML file.
 

--- a/acoular/grids.py
+++ b/acoular/grids.py
@@ -50,7 +50,6 @@ from traits.api import (
     Union,
     cached_property,
     observe,
-    on_trait_change,
     property_depends_on,
 )
 from traits.trait_errors import TraitError
@@ -883,8 +882,8 @@ class ImportGrid(Grid):
     def _set_pos(self, pos):
         self._gpos = pos
 
-    @on_trait_change('file')
-    def import_gpos(self):
+    @observe('file')
+    def import_gpos(self, event):  # noqa ARG002
         """
         Import the grid point locations and subgrid names from an XML file.
 

--- a/acoular/microphones.py
+++ b/acoular/microphones.py
@@ -24,7 +24,7 @@ from traits.api import (
     Property,
     Union,
     cached_property,
-    on_trait_change,
+    observe,
 )
 
 # acoular imports
@@ -199,8 +199,8 @@ class MicGeom(HasStrictTraits):
             return cdist(self.pos.T, self.pos.T).max()
         return None
 
-    @on_trait_change('file')
-    def _import_mpos(self):
+    @observe('file')
+    def _import_mpos(self, event):  # noqa ARG002
         # Import the microphone positions from an XML file.
         #
         # This method parses the XML file specified in :attr:`file` and extracts the ``x``, ``y``,

--- a/acoular/process.py
+++ b/acoular/process.py
@@ -19,7 +19,7 @@ from inspect import currentframe
 from warnings import warn
 
 import numpy as np
-from traits.api import Any, Array, Bool, Dict, Enum, Instance, Int, Property, Union, cached_property, on_trait_change
+from traits.api import Any, Array, Bool, Dict, Enum, Instance, Int, Property, Union, cached_property, observe
 
 # acoular imports
 from .base import Generator, InOut
@@ -542,8 +542,8 @@ class SampleSplitter(InOut):
         next_block = next(self._source_generator)
         [self.block_buffer[obj].appendleft(next_block) for obj in self.block_buffer]
 
-    @on_trait_change('buffer_size')
-    def _change_buffer_size(self):  #
+    @observe('buffer_size')
+    def _change_buffer_size(self, event):  # noqa: ARG002
         for obj in self.block_buffer:
             self._remove_block_buffer(obj)
             self._create_block_buffer(obj)

--- a/acoular/sources.py
+++ b/acoular/sources.py
@@ -54,7 +54,6 @@ from traits.api import (
     Union,
     cached_property,
     observe,
-    on_trait_change,
 )
 
 from .base import SamplesGenerator
@@ -393,8 +392,8 @@ class TimeSamples(SamplesGenerator):
     def _get_basename(self):
         return get_file_basename(self.file)
 
-    @on_trait_change('basename')
-    def _load_data(self):
+    @observe('basename')
+    def _load_data(self, event):  # noqa ARG002
         # Open the .h5 file and set attributes.
         if self.h5f is not None:
             with contextlib.suppress(OSError):
@@ -404,8 +403,8 @@ class TimeSamples(SamplesGenerator):
         self._load_timedata()
         self._load_metadata()
 
-    @on_trait_change('data')
-    def _load_shapes(self):
+    @observe('data')
+    def _load_shapes(self, event):  # noqa ARG002
         # Set :attr:`num_channels` and :attr:`num_samples` from data.
         if self.data is not None:
             self.num_samples, self.num_channels = self.data.shape
@@ -611,8 +610,8 @@ class MaskedTimeSamples(TimeSamples):
         sli = slice(self.start, self.stop).indices(self.num_samples_total)
         return sli[1] - sli[0]
 
-    @on_trait_change('basename')
-    def _load_data(self):
+    @observe('basename')
+    def _load_data(self, event):  # noqa ARG002
         # Open the .h5 file and set attributes.
         if not path.isfile(self.file):
             # no file there
@@ -627,8 +626,8 @@ class MaskedTimeSamples(TimeSamples):
         self._load_timedata()
         self._load_metadata()
 
-    @on_trait_change('data')
-    def _load_shapes(self):
+    @observe('data')
+    def _load_shapes(self, event):  # noqa ARG002
         # Set :attr:`num_channels` and num_samples from :attr:`~acoular.sources.TimeSamples.data`.
         if self.data is not None:
             self.num_samples_total, self.num_channels_total = self.data.shape

--- a/acoular/tprocess.py
+++ b/acoular/tprocess.py
@@ -64,7 +64,6 @@ from traits.api import (
     Union,
     cached_property,
     observe,
-    on_trait_change,
 )
 
 # acoular imports
@@ -690,8 +689,8 @@ class AngleTracker(MaskedTimeOut):
         self._calc_flag = True
 
     # reset calc flag if something has changed
-    @on_trait_change('digest')
-    def _reset_calc_flag(self):
+    @observe('digest')
+    def _reset_calc_flag(self, event):  # noqa ARG002
         self._calc_flag = False
 
     # calc rpm from trigger data

--- a/docs/source/news/index.rst
+++ b/docs/source/news/index.rst
@@ -10,6 +10,7 @@ Upcoming Release
     **Internal**
         * refactored import statements and input aliases
         * removed duplicate code in `MovingPointSource`-derived classes
+        * migrate from traits `on_trait_change` to `observe`
 
 25.07
 ------------------------


### PR DESCRIPTION

### Description
This pull request replaces the deprecated `on_trait_change` decorator with the `observe` decorator across multiple files in the codebase to modernize the code and ensure compatibility with the latest version of the Traits library. Below is a categorized summary of the changes:


### Reference issue
<!-- If this pull request closes a issue, please denote it like: Closes #141. -->
Closes #153 

### Checklist
<!-- Please make sure that your pull request checks all the boxes. -->
- [x] I have read the [Contributing](https://www.acoular.org/contributing/index.html) section.
- [x] My branch is up-to-date with the *master* branch of the [Acoular repository](https://github.com/acoular/acoular).
- [x] My changes fulfill the [Code Quality](https://www.acoular.org/contributing/quality.html) standards.
- [x] I have updated the [What's new](https://www.acoular.org/news/index.html) section the the [documentation](https://github.com/acoular/acoular/blob/master/docs/source/news/index.rst) explaining my changes.
- [ ] I have appended myself to the [CITATION.cff](https://github.com/acoular/acoular/blob/master/CITATION.cff) file.
