### PR TITLE
Fix docstrings for ``h5files.py``

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -75,7 +75,6 @@ docstring-code-line-length = "dynamic"
 "acoular/environments.py" = ["N806"]
 "acoular/fastFuncs.py" = ["N802", "N803", "N806", "N999"] # allow different naming convention
 "acoular/fbeamform.py" = ["N806", "B023"]
-"acoular/h5files.py" = ["D102"]
 "acoular/sources.py" = ["N806"]
 "acoular/tools/helpers.py" = ["D205"]
 "acoular/tprocess.py" = ["N806"]

--- a/acoular/h5files.py
+++ b/acoular/h5files.py
@@ -56,6 +56,7 @@ class H5FileBase:
         value : any
             The value to assign to the attribute.
         """
+
     def get_node_attribute(self, node, attrname):
         """
         Get an attribute from a node.

--- a/acoular/h5files.py
+++ b/acoular/h5files.py
@@ -11,20 +11,78 @@ class H5FileBase:
     """Base class for File objects that handle writing and reading of .h5 files."""
 
     def create_extendable_array(self, nodename, shape, precision, group=None):
-        """Create an extendable array in the HDF5 file."""
+        """
+        Create an extendable array in the HDF5 file.
 
+        Parameters
+        ----------
+        nodename : :class:`str`
+            Name of the node (dataset) to create in the HDF5 file.
+        shape : :class:`tuple` of :class:`int`
+            Shape of the array to be created.
+        precision : :class:`str`
+            Data type/precision of the array (e.g., 'float32', 'int16').
+        group : :class:`pytables.Group`, optional
+            Group in which to create the array. If None, the root group is used.
+        """
     def get_data_by_reference(self, nodename, group=None):
-        """Get data by reference from the HDF5 file."""
+        """
+        Get data by reference from the HDF5 file.
 
+        Parameters
+        ----------
+        nodename : :class:`str`
+            Name of the node (dataset or group) to retrieve from the HDF5 file.
+        group : object, optional
+            The parent group in which to look for the node. If None, the root group is used.
+
+        Returns
+        -------
+        object
+            A reference to the requested node (e.g., a dataset or group object) in the HDF5 file.
+        """
     def set_node_attribute(self, node, attrname, value):
-        """Set an attribute on a node."""
+        """
+        Set an attribute on a node.
 
+        Parameters
+        ----------
+        node : object
+            The node (e.g., group or dataset) to which the attribute will be set.
+        attrname : :class:`str`
+            The name of the attribute to set.
+        value : any
+            The value to assign to the attribute.
+        """
     def get_node_attribute(self, node, attrname):
-        """Get an attribute from a node."""
+        """
+        Get an attribute from a node.
 
+        Parameters
+        ----------
+        node : object
+            The node (e.g., group or dataset) from which to retrieve the attribute.
+        attrname : :class:`str`
+            The name of the attribute to retrieve.
+
+        Returns
+        -------
+        object
+            The value of the specified attribute.
+        """
     def append_data(self, node, data):
-        """Append data to an existing node."""
+        """
+        Append data to an existing node.
 
+        Parameters
+        ----------
+        node : object
+            The node (e.g., array or dataset) in the HDF5 file to which data will be appended.
+            The expected type depends on the backend (e.g., PyTables node or h5py dataset).
+        data : array-like
+            The data to append. Should be compatible in shape and type with the existing node.
+            The format and type must match the node's requirements.
+        """
     def remove_data(self, nodename):
         """Remove data from the HDF5 file."""
 

--- a/acoular/h5files.py
+++ b/acoular/h5files.py
@@ -22,9 +22,10 @@ class H5FileBase:
             Shape of the array to be created.
         precision : :class:`str`
             Data type/precision of the array (e.g., 'float32', 'int16').
-        group : :class:`pytables.Group`, optional
+        group : object, optional
             Group in which to create the array. If None, the root group is used.
         """
+
     def get_data_by_reference(self, nodename, group=None):
         """
         Get data by reference from the HDF5 file.
@@ -41,6 +42,7 @@ class H5FileBase:
         object
             A reference to the requested node (e.g., a dataset or group object) in the HDF5 file.
         """
+
     def set_node_attribute(self, node, attrname, value):
         """
         Set an attribute on a node.
@@ -70,6 +72,7 @@ class H5FileBase:
         object
             The value of the specified attribute.
         """
+
     def append_data(self, node, data):
         """
         Append data to an existing node.
@@ -83,6 +86,7 @@ class H5FileBase:
             The data to append. Should be compatible in shape and type with the existing node.
             The format and type must match the node's requirements.
         """
+
     def remove_data(self, nodename):
         """Remove data from the HDF5 file."""
 

--- a/acoular/h5files.py
+++ b/acoular/h5files.py
@@ -11,25 +11,25 @@ class H5FileBase:
     """Base class for File objects that handle writing and reading of .h5 files."""
 
     def create_extendable_array(self, nodename, shape, precision, group=None):
-        pass
+        """Create an extendable array in the HDF5 file."""
 
     def get_data_by_reference(self, nodename, group=None):
-        pass
+        """Get data by reference from the HDF5 file."""
 
     def set_node_attribute(self, node, attrname, value):
-        pass
+        """Set an attribute on a node."""
 
     def get_node_attribute(self, node, attrname):
-        pass
+        """Get an attribute from a node."""
 
     def append_data(self, node, data):
-        pass
+        """Append data to an existing node."""
 
     def remove_data(self, nodename):
-        pass
+        """Remove data from the HDF5 file."""
 
     def create_new_group(self, name, group=None):
-        pass
+        """Create a new group in the HDF5 file."""
 
 
 class H5CacheFileBase:
@@ -38,10 +38,10 @@ class H5CacheFileBase:
     compression_filter = None
 
     def is_cached(self, nodename, group=None):
-        pass
+        """Check if data is cached in the HDF5 file."""
 
     def create_compressible_array(self, nodename, shape, precision, group=None):
-        pass
+        """Create a compressible array in the HDF5 cache file."""
 
 
 if config.have_tables:
@@ -62,34 +62,42 @@ if config.have_tables:
         """Hdf5 File based on PyTables."""
 
         def create_extendable_array(self, nodename, shape, precision, group=None):
+            """Create an extendable array using PyTables."""
             if not group:
                 group = self.root
             atom = precision_to_atom[precision]
             self.create_earray(group, nodename, atom, shape)
 
         def get_data_by_reference(self, nodename, group=None):
+            """Get data by reference using PyTables."""
             if not group:
                 group = self.root
             return self.get_node(group, nodename)
 
         def set_node_attribute(self, node, attrname, value):
+            """Set an attribute on a PyTables node."""
             node.set_attr(attrname, value)
 
         def get_node_attribute(self, node, attrname):
+            """Get an attribute from a PyTables node."""
             return node._v_attrs[attrname]  # noqa: SLF001
 
         def append_data(self, node, data):
+            """Append data to a PyTables node."""
             node.append(data)
 
         def remove_data(self, nodename):
+            """Remove data from PyTables file."""
             self.remove_node('/', nodename, recursive=True)
 
         def create_new_group(self, name, group=None):
+            """Create a new group in PyTables file."""
             if not group:
                 group = self.root
             return self.create_group(group, name)
 
         def get_child_nodes(self, nodename):
+            """Get child nodes from a PyTables group."""
             for childnode in self.list_nodes(nodename):
                 yield (childnode.name, childnode)
 
@@ -115,11 +123,13 @@ if config.have_tables:
         compression_filter = tables.Filters(complevel=5, complib='blosc')
 
         def is_cached(self, nodename, group=None):
+            """Check if data is cached in PyTables file."""
             if not group:
                 group = self.root
             return nodename in group
 
         def create_compressible_array(self, nodename, shape, precision, group=None):
+            """Create a compressible array in PyTables cache file."""
             if not group:
                 group = self.root
             atom = precision_to_atom[precision]
@@ -133,43 +143,53 @@ if config.have_h5py:
         """Hdf5 File based on h5py."""
 
         def _get_in_file_path(self, nodename, group=None):
+            """Get the in-file path for h5py operations."""
             if not group:
                 return '/' + nodename
             return group + '/' + nodename
 
         def create_array(self, where, name, obj):
+            """Create an array in h5py file."""
             self.create_dataset(f'{where}/{name}', data=obj)
 
         def create_extendable_array(self, nodename, shape, precision, group=None):
+            """Create an extendable array using h5py."""
             in_file_path = self._get_in_file_path(nodename, group)
             self.create_dataset(in_file_path, shape=shape, dtype=precision, maxshape=(None, shape[1]))
 
         def get_data_by_reference(self, nodename, group=None):
+            """Get data by reference using h5py."""
             in_file_path = self._get_in_file_path(nodename, group)
             return self[in_file_path]
 
         def set_node_attribute(self, node, attrname, value):
+            """Set an attribute on an h5py node."""
             node.attrs[attrname] = value
 
         def get_node_attribute(self, node, attrname):
+            """Get an attribute from an h5py node."""
             return node.attrs[attrname]
 
         def append_data(self, node, data):
+            """Append data to an h5py dataset."""
             old_shape = node.shape
             new_shape = (old_shape[0] + data.shape[0], data.shape[1])
             node.resize(new_shape)
             node[old_shape[0] : new_shape[0], :] = data
 
         def remove_data(self, nodename, group=None):
+            """Remove data from h5py file."""
             in_file_path = self._get_in_file_path(nodename, group)
             del self[in_file_path]
 
         def create_new_group(self, name, group=None):
+            """Create a new group in h5py file."""
             in_file_path = self._get_in_file_path(name, group)
             self.create_group(in_file_path)
             return in_file_path
 
         def get_child_nodes(self, nodename):
+            """Get child nodes from an h5py group."""
             for childnode in self[nodename]:
                 yield (childnode, self[f'{nodename}/{childnode}'])
 
@@ -196,11 +216,13 @@ if config.have_h5py:
         #        compression_filter = 'blosc' # unavailable...
 
         def is_cached(self, nodename, group=None):
+            """Check if data is cached in h5py file."""
             if not group:
                 group = '/'
             return group + nodename in self
 
         def create_compressible_array(self, nodename, shape, precision, group=None):
+            """Create a compressible array in h5py cache file."""
             in_file_path = self._get_in_file_path(nodename, group)
             self.create_dataset(
                 in_file_path,
@@ -212,6 +234,7 @@ if config.have_h5py:
 
 
 def _get_h5file_class():
+    """Get the appropriate H5File class based on configuration."""
     if config.h5library in ['pytables', 'tables']:
         return H5FileTables
     if config.h5library == 'h5py':
@@ -220,6 +243,7 @@ def _get_h5file_class():
 
 
 def _get_cachefile_class():
+    """Get the appropriate H5CacheFile class based on configuration."""
     if config.h5library in ['pytables', 'tables']:
         return H5CacheFileTables
     if config.h5library == 'h5py':

--- a/docs/source/news/index.rst
+++ b/docs/source/news/index.rst
@@ -22,7 +22,7 @@ Upcoming Release
         * changes all appearances of :meth:`~acoular.grids.RectGrid.extend` to :attr:`~acoular.grids.RectGrid.extent`
         * introduces a deprecation policy in the contributing guidelines
         * adds new docstrings to submodule :mod:`acoular.tprocess`
-        * adds new docstrings to submodule :mod:`acoular.h5cache`
+        * adds new docstrings to submodule :mod:`acoular.h5cache` and :mod:`acoular.h5files`
         * fix docstrings in submodule :mod:`acoular.fbeamform` to fulfill linting rules
 
     **Tests**


### PR DESCRIPTION
### Description
- add missing docstings to public methods in ``h5files.py``
- remove ``pass`` statements to prevent linting errors

### Reference issue
#216
Closes #504

### Checklist
<!-- Please make sure that your pull request checks all the boxes. -->
- [x] I have read the [Contributing](https://www.acoular.org/contributing/index.html) section.
- [x] My branch is up-to-date with the *master* branch of the [Acoular repository](https://github.com/acoular/acoular).
- [x] My changes fulfill the [Code Quality](https://www.acoular.org/contributing/quality.html) standards.
- [x] I have updated the [What's new](https://www.acoular.org/news/index.html) section the the [documentation](https://github.com/acoular/acoular/blob/master/docs/source/news/index.rst) explaining my changes.
- [x] I have appended myself to the [CITATION.cff](https://github.com/acoular/acoular/blob/master/CITATION.cff) file.
