### PR TITLE
Fix docstrings for ``h5cache.py``

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -75,7 +75,6 @@ docstring-code-line-length = "dynamic"
 "acoular/environments.py" = ["N806"]
 "acoular/fastFuncs.py" = ["N802", "N803", "N806", "N999"] # allow different naming convention
 "acoular/fbeamform.py" = ["N806", "B023", "D205"]
-"acoular/h5cache.py" = ["D102"]
 "acoular/h5files.py" = ["D102"]
 "acoular/sources.py" = ["N806"]
 "acoular/tools/helpers.py" = ["D205"]

--- a/acoular/h5cache.py
+++ b/acoular/h5cache.py
@@ -32,21 +32,25 @@ class HDF5Cache(HasStrictTraits):
             pass
 
     def close_cachefile(self, cachefile):
+        """Close a cache file and remove it from the reference counter."""
         self.open_file_reference.pop(Path(cachefile.filename))
         cachefile.close()
 
     def get_open_cachefiles(self):
+        """Get an iterator over all open cache files."""
         try:
             return self.open_files.itervalues()
         except AttributeError:
             return iter(self.open_files.values())
 
     def close_unreferenced_cachefiles(self):
+        """Close cache files that are no longer referenced by any objects."""
         for cachefile in self.get_open_cachefiles():
             if not self.is_reference_existent(cachefile):
                 self.close_cachefile(cachefile)
 
     def is_reference_existent(self, file):
+        """Check if a file object still has active references."""
         exist_flag = False
         # inspect all refererres to the file object
         gc.collect()  # clear garbage before collecting referrers

--- a/acoular/h5cache.py
+++ b/acoular/h5cache.py
@@ -52,7 +52,7 @@ class HDF5Cache(HasStrictTraits):
     def is_reference_existent(self, file):
         """Check if a file object still has active references."""
         exist_flag = False
-        # inspect all refererres to the file object
+        # inspect all referrers to the file object
         gc.collect()  # clear garbage before collecting referrers
         for ref in gc.get_referrers(file):
             # does the file object have a referrer that has a 'h5f'

--- a/docs/source/news/index.rst
+++ b/docs/source/news/index.rst
@@ -22,6 +22,7 @@ Upcoming Release
         * changes all appearances of :meth:`~acoular.grids.RectGrid.extend` to :attr:`~acoular.grids.RectGrid.extent`
         * introduces a deprecation policy in the contributing guidelines
         * adds new docstrings to submodule :mod:`acoular.tprocess`
+        * adds new docstrings to submodule :mod:`acoular.h5cache`
 
     **Tests**
         * add tests for export and load XML functionalities of :class:`~acoular.grids.Grid`


### PR DESCRIPTION
### Description
- add missing docstrings to public methods in ``h5cache.py``

### Reference issue
#216
Closes #506

### Checklist
<!-- Please make sure that your pull request checks all the boxes. -->
- [x] I have read the [Contributing](https://www.acoular.org/contributing/index.html) section.
- [x] My branch is up-to-date with the *master* branch of the [Acoular repository](https://github.com/acoular/acoular).
- [x] My changes fulfill the [Code Quality](https://www.acoular.org/contributing/quality.html) standards.
- [x] I have updated the [What's new](https://www.acoular.org/news/index.html) section the the [documentation](https://github.com/acoular/acoular/blob/master/docs/source/news/index.rst) explaining my changes.
- [x] I have appended myself to the [CITATION.cff](https://github.com/acoular/acoular/blob/master/CITATION.cff) file.
