### PR TITLE
Reuse Examples in user guide

### DIFF
--- a/docs/user_guide/caching.rst
+++ b/docs/user_guide/caching.rst
@@ -13,6 +13,9 @@ Lazy evaluation decides when a calculation is needed. Caching decides whether
 Acoular can reuse data from an earlier calculation. This chapter explains the
 file-based caching controls.
 
+The code snippets below are taken from
+:doc:`../auto_examples/introductory_examples/example_caching`.
+
 What Is Cached
 --------------
 
@@ -41,16 +44,27 @@ setting, which is available as ``ac.config.cache_dir``. If no cache directory is
 set explicitly, Acoular creates and uses a directory named ``cache`` below the
 current working directory when the cache is first needed.
 
-.. code-block:: python
+.. literalinclude:: ../../examples/introductory_examples/example_caching.py
+   :language: python
+   :start-after: # Configure cache directory, backend, and global mode.
+   :end-before: # Define shared geometry and input data.
 
-    import acoular as ac
+The remaining examples on this page use the standard introductory setup:
 
-    ac.config.cache_dir = "my_cache"
+.. literalinclude:: ../../examples/introductory_examples/example_caching.py
+   :language: python
+   :start-after: # Define shared geometry and input data.
+   :end-before: # Use object-level caching controls.
 
 Cache files use the suffix ``_cache.h5``. Where possible, the file name is based
 on the original source data. For example, processing data from
 ``three_sources.h5`` typically creates a cache file named
 ``three_sources_cache.h5``.
+
+.. literalinclude:: ../../examples/introductory_examples/example_caching.py
+   :language: python
+   :start-after: # Check the generated cache file.
+   :end-before: # Force recalculation in overwrite mode.
 
 Inside a cache file, Acoular stores results under names that include a digest.
 The digest is calculated from the class and the traits that affect the result,
@@ -92,6 +106,13 @@ result to be recalculated. Use ``"readonly"`` when working with a shared or
 archived cache directory that should not be modified. Use ``"overwrite"`` when
 you deliberately want to refresh existing cache entries.
 
+The following example shows ``"overwrite"`` in use:
+
+.. literalinclude:: ../../examples/introductory_examples/example_caching.py
+   :language: python
+   :start-after: # Force recalculation in overwrite mode.
+   :end-before: # Explicitly cache a time-domain processing chain.
+
 Object-Level Caching
 --------------------
 
@@ -99,12 +120,10 @@ Some classes also provide a ``cached`` trait. In the default
 ``global_caching="individual"`` mode, this trait controls whether that object
 uses the file cache.
 
-.. code-block:: python
-
-    ps = ac.PowerSpectra(source=ts, block_size=128, window="Hanning")
-    ps.cached = False  # calculate PowerSpectra results without using file cache
-
-    bb = ac.BeamformerBase(freq_data=ps, steer=st, cached=True)
+.. literalinclude:: ../../examples/introductory_examples/example_caching.py
+   :language: python
+   :start-after: # Use object-level caching controls.
+   :end-before: # Check the generated cache file.
 
 The object-level ``cached`` trait is ignored by the global ``"all"``,
 ``"none"``, ``"readonly"``, and ``"overwrite"`` modes. Those modes are intended
@@ -118,15 +137,9 @@ a block-wise generator and will be consumed more than once. It is often used in
 time-domain processing chains, where repeating all upstream calculations would
 be expensive.
 
-.. code-block:: python
-
-    fft = ac.RFFT(source=ts, block_size=1024)
-    cached_fft = ac.Cache(source=fft)
-
-    for block in cached_fft.result(num=8):
-        # The first pass calculates blocks and writes them to the cache.
-        # Later passes can read the same blocks from the cache.
-        pass
+.. literalinclude:: ../../examples/introductory_examples/example_caching.py
+   :language: python
+   :start-after: # Explicitly cache a time-domain processing chain.
 
 If a :class:`~acoular.process.Cache` object finds an incomplete cache entry, it
 continues safely according to the global cache mode. In normal writable modes,
@@ -139,11 +152,6 @@ Choosing The HDF5 Backend
 Acoular can use either PyTables or h5py for HDF5 cache files. The backend is
 selected with the :attr:`~acoular.configuration.Config.h5library` setting, which
 is available as ``ac.config.h5library``.
-
-.. code-block:: python
-
-    ac.config.h5library = "pytables"  # default when PyTables is available
-    ac.config.h5library = "h5py"
 
 Both backends write HDF5 files. PyTables is preferred when available; if it is
 not installed, Acoular uses h5py.

--- a/docs/user_guide/caching.rst
+++ b/docs/user_guide/caching.rst
@@ -47,14 +47,14 @@ current working directory when the cache is first needed.
 .. literalinclude:: ../../examples/introductory_examples/example_caching.py
    :language: python
    :start-after: # Configure cache directory, backend, and global mode.
-   :end-before: # Define shared geometry and input data.
+   :end-before: # %%
 
 The remaining examples on this page use the standard introductory setup:
 
 .. literalinclude:: ../../examples/introductory_examples/example_caching.py
    :language: python
    :start-after: # Define shared geometry and input data.
-   :end-before: # Use object-level caching controls.
+   :end-before: # %%
 
 Cache files use the suffix ``_cache.h5``. Where possible, the file name is based
 on the original source data. For example, processing data from
@@ -64,7 +64,7 @@ on the original source data. For example, processing data from
 .. literalinclude:: ../../examples/introductory_examples/example_caching.py
    :language: python
    :start-after: # Check the generated cache file.
-   :end-before: # Force recalculation in overwrite mode.
+   :end-before: # %%
 
 Inside a cache file, Acoular stores results under names that include a digest.
 The digest is calculated from the class and the traits that affect the result,
@@ -111,7 +111,7 @@ The following example shows ``"overwrite"`` in use:
 .. literalinclude:: ../../examples/introductory_examples/example_caching.py
    :language: python
    :start-after: # Force recalculation in overwrite mode.
-   :end-before: # Explicitly cache a time-domain processing chain.
+   :end-before: # %%
 
 Object-Level Caching
 --------------------
@@ -123,8 +123,8 @@ uses the file cache.
 .. literalinclude:: ../../examples/introductory_examples/example_caching.py
    :language: python
    :start-after: # Use object-level caching controls.
-   :end-before: # Check the generated cache file.
-
+   :end-before: # %%
+   
 The object-level ``cached`` trait is ignored by the global ``"all"``,
 ``"none"``, ``"readonly"``, and ``"overwrite"`` modes. Those modes are intended
 for session-wide control.

--- a/docs/user_guide/get_started.rst
+++ b/docs/user_guide/get_started.rst
@@ -3,168 +3,155 @@
 Getting Started
 ===============
 
-The Acoular library is based on the Python programming language. While a basic knowledge of Python is definitely helpful, the following first steps do not require this. A number of good Python tutorials can be found on the web. 
+The Acoular library is based on Python. This guide walks through a small
+frequency-domain beamforming workflow using the same example scripts that are
+built and tested in the documentation gallery.
 
 Prerequisites
 -------------
-This "Getting started" tutorial assumes that the Acoular library is :doc:`installed<../install/index>` together with its dependencies and ``matplotlib``, and that the demo finished successfully. If you did not run the demo yet, you should do so by typing into your python console
 
-.. ipython::
-    :okwarning:
+This tutorial assumes that Acoular is :doc:`installed<../install/index>`
+together with its dependencies and ``matplotlib``.
 
-    In [1]: import acoular
-    
-    In [1]: acoular.demo.run()
+If you have not run the demo yet, run ``acoular.demo.run()`` in Python once.
+Besides checking that the installation works, the demo creates a
+``three_sources.h5`` file in the current working directory. The following
+example uses that file.
 
-This should, after some seconds, produce two pictures (a 64 microphone arrangement and a beamforming map with three sources). You may close the pictures in order to continue. 
+The full runnable scripts used on this page are:
 
-Apart from showing that everything works well, the demo also produced some data to work on. You should now have a ***file 'three_sources.h5' (13MB)** in your working directory.
+* :doc:`../auto_examples/introductory_examples/example_three_sources`
+* :doc:`../auto_examples/introductory_examples/example_basic_beamforming`
 
-Beamforming example step-by-step 
+Generate Example Data
+---------------------
+
+If you want to create the input data yourself instead of using the demo output,
+the gallery example :doc:`../auto_examples/introductory_examples/example_three_sources`
+generates a synthetic measurement file with three sources.
+
+The example imports Acoular and defines the output file and basic signal setup:
+
+.. literalinclude:: ../../examples/introductory_examples/example_three_sources.py
+   :language: python
+   :start-after: # Import packages.
+   :end-before: # Generate and store the example data.
+
+Then it creates three point sources, mixes them, and writes the result to
+``three_sources.h5``:
+
+.. literalinclude:: ../../examples/introductory_examples/example_three_sources.py
+   :language: python
+   :start-after: # Generate and store the example data.
+   :end-before: # %%
+
+Beamforming Example Step By Step
 --------------------------------
 
-One possible way to use the library is for doing classic delay-and-sum beamforming. This can either be done directly in the time domain or in the frequency domain. To get started with Acoular, we will present a very basic example of beamforming in the frequency domain. In order to perform such an analysis we do need some data to work on. In a practical application, this data is acquired during multichannel measurements using a microphone array. The library provides some functionality to do so and stores the measured sound pressure time histories for all channels of the microphone array in a hierarchical data file (HDF5) format. 
-However, a working measurement set-up is required. Thus, we will use simulated data here. The 'three_sources.h5' file, generated using Acoular's simulation capabilities (see the :doc:`reference <../api_ref/index>`), contains the time history data for 64 microphone channels, which are sampled at 51200 Hz for a duration of 1 second, i.e. 51200 samples per channel. 
+One common Acoular workflow is classic delay-and-sum beamforming in the
+frequency domain. The gallery example
+:doc:`../auto_examples/introductory_examples/example_basic_beamforming`
+contains the full runnable script. This section walks through the same script in
+small pieces.
 
-In what follows, it is assumed that an interactive python session is started, preferably an IPython or jupyter session:
+First, import the required packages and define the paths to the microphone
+geometry and the input data:
 
->>> ipython
+.. literalinclude:: ../../examples/introductory_examples/example_basic_beamforming.py
+   :language: python
+   :start-after: # Import packages.
+   :end-before: # Load geometry and time data.
 
-Then, the first step to perform an analysis is to import the Acoular library:
+The microphone geometry is loaded from the Acoular package, and the time-domain
+measurement data is accessed through a :class:`~acoular.sources.TimeSamples`
+object:
 
-.. ipython::
+.. literalinclude:: ../../examples/introductory_examples/example_basic_beamforming.py
+   :language: python
+   :start-after: # Load geometry and time data.
+   :end-before: # Define spectral processing.
 
-    In [1]: import acoular
+The ``ts`` object provides access to the HDF5 file and its metadata. The sample
+data is not loaded into memory all at once. Instead, Acoular reads it in blocks
+when later processing steps request it.
 
-This makes all the functionality available needed for the beamforming analysis. We start with making the data from the HDF5 file available and create and instance of :class:`~acoular.sources.TimeSamples` :
+Next, define the spectral processing. The
+:class:`~acoular.spectra.PowerSpectra` object computes the cross-spectral
+matrix using Welch's method with a block size of 128 samples and a Hanning
+window:
 
-.. ipython::
+.. literalinclude:: ../../examples/introductory_examples/example_basic_beamforming.py
+   :language: python
+   :start-after: # Define spectral processing.
+   :end-before: # Define grid and steering vector.
 
-    In [1]: ts = acoular.TimeSamples( file='three_sources.h5' )
+At this point no cross-spectral matrix has been calculated yet. Acoular uses
+:ref:`lazy_evaluation`, so the expensive work starts only when a result is
+actually requested.
 
-The ts object now provides access to the HDF5 file and information stored in it. 
+To beamform, define a focus grid and steering vector:
 
-.. ipython::
+.. literalinclude:: ../../examples/introductory_examples/example_basic_beamforming.py
+   :language: python
+   :start-after: # Define grid and steering vector.
+   :end-before: # Calculate beamforming result.
 
-    In [1]: ts
+The grid contains the candidate source positions. The steering vector combines
+that grid with the microphone geometry and sound propagation model.
 
-    In [1]: ts.sample_freq
+Now create the beamformer and request a third-octave map around 8000 Hz:
 
-It is important to note that the data in the file is **not read into the memory** for it could be very large (i.e. several GB). Instead, the data is read in small chunks the moment it is needed. Because this is done automatically, the user does not have to take care of that.
+.. literalinclude:: ../../examples/introductory_examples/example_basic_beamforming.py
+   :language: python
+   :start-after: # Calculate beamforming result.
+   :end-before: # Plot beamforming map.
 
-The beamforming shall be done in the frequency domain. In this case the cross spectral matrix is the basis. This matrix consists of the cross power spectra of all possible combinations of channels. Here, this gives 64²=4096 cross power spectra. These spectra are computed using Welch's method, i.e. blocks of samples are taken from the signals and Fourier-transformed using FFT, used to calculate the power spectra, and then the results are averaged over a number of blocks. The blocks have a certain length and may be overlapping. In addition, a windowing function may be applied to each block prior to the FFT. To provide the facilities to calculate the cross spectral matrix we create an instance of :class:`~acoular.spectra.PowerSpectra` and define the size of the blocks to be 128 samples and a von-Hann ('Hanning') window to be used:
+This is the line where processing starts. Acoular reads the time data,
+calculates the cross-spectral matrix, performs beamforming, and converts the
+result to decibels.
 
-.. ipython::
+Plotting The Result
+-------------------
 
-    In [1]: ps = acoular.PowerSpectra( source=ts, block_size=128, window='Hanning' )
+The beamforming map is plotted as:
 
-The data for the calculation is to be taken from the ts object that was created before. Because the calculation of the cross spectral matrix is a time consuming process, no calculation is performed at the moment, but is **delayed** until the result is actually needed. This concept of :ref:`lazy_evaluation` is applied wherever possible throughout the Acoular library. This prevents unnecessary time-consuming computations. Another option to set the parameters for the Welch method would have been to first create a 'blank' or 'default' :class:`~acoular.spectra.PowerSpectra` object and set the parameters, or traits of the object, afterwards:
-
-.. ipython::
-
-    In [1]: ps = acoular.PowerSpectra()
-
-    In [1]: ps.source = ts
-
-    In [1]: ps.block_size = 128
-
-    In [1]: ps.window='Hanning'
-
-If one or more parameters are changed after the computation of the cross spectral matrix, it will be automatically **recalculated** the next time it is needed.
-
-Our aim is to produce a mapping of the acoustic sources. Because such a map can be produced only when having a number of possible source positions available, these positions must be provided by creating a :class:`~acoular.grids.Grid` object. More specifically, we want to create a :class:`~acoular.grids.RectGrid` object, which provides possible source positions in a regular, two-dimensional grid with rectangular shape:
-
-.. ipython:: 
-
-    In [1]: rg = acoular.RectGrid( x_min=-0.2, x_max=0.2, y_min=-0.2, y_max=0.2, z=-0.3, increment=0.01 )
- 
-The traits assigned in brackets determine the dimensions of the grid and distance (increment) between individual source positions. Using
-
-.. ipython:: 
-
-    In [1]: rg.size
-
-we can ask about the number of possible source positions in the grid.
-
-The positions of the microphones are needed for beamforming, so we create a :class:`~acoular.microphones.MicGeom` object, that reads the positions from a .xml file. Here we use array_64.xml, which is part of the library. To access the location of the file we first have to import the os.path library (part of standard python) and query the location of the file in the file system.
-
-.. ipython:: 
-
-    In [1]: from pathlib import Path
-
-    In [1]: micgeofile = Path(acoular.__file__).parent / 'xml' / 'array_64.xml'
-
-    In [1]: mg = acoular.MicGeom( file=micgeofile )
-
-In order to plot the microphone arrangement, we make use of the convenient matplotlib library with its pylab interface:
-
-.. ipython:: 
-
-    In [1]: import pylab as plt
-
-    In [1]: plt.ion() # switch on interactive plotting mode
-
-    In [1]: plt.plot(mg.pos[0],mg.pos[1],'o')
-
-.. figure:: array64_py3colormap.png
-   :align: center
-   :scale: 50%
-
-The sound propagation model (including the source model and transfer path) is contained in a :class:`~acoular.fbeamform.SteeringVector` object, which is given the focus grid and microphone arrangement to calculate the steering vector, which also contains a weighting of the transfer functions from grid points to microphone positions:
-
-.. ipython:: 
-
-    In [1]: st = acoular.SteeringVector( grid=rg, mics=mg )
-
-Finally, we can create the object that encapsulates the delay-and-sum algorithm. The basic beamforming algorithm is provided by objects of the type :class:`~acoular.fbeamform.BeamformerBase` 
-
-.. ipython:: 
-
-    In [1]: bb = acoular.BeamformerBase( freq_data=ps, steer=st )
-
-The cross spectral matrix and the steering vector, which were created before, are used here as input data. Still, **up to now, no computation has been done** because no result was needed yet. Using 
-
-.. ipython:: 
-
-    In [1]: pm = bb.synthetic( 8000, 3 )
-
-    In [1]: Lm = acoular.L_p( pm )
-
-the beamforming result mapped onto the grid is queried for a frequency of 8000 Hz and over a third-octave wide frequency band (thus the '3' in the second argument). As a consequence, processing starts: the data is read from the file, the cross spectral matrix is computed and the beamforming is performed. The result (sound pressure squared) is given as an array with the same shape as the grid. Using the helper function :class:`~acoular.fbeamform.L_p`, this is converted to decibels.
-
-Now let us plot the result:
-
-.. ipython:: 
-
-    In [1]: plt.figure() # open new figure
-
-    In [1]: plt.imshow( Lm.T, origin='lower', vmin=Lm.max()-10, extent=rg.extent, interpolation='bicubic')
-
-    In [1]: plt.colorbar()
-
-
-which shows the following map, scaled to a range between the maximum value and 10 dB below it, and with the axes scales derived from the :class:`~acoular.grids.RectGrid` data object. 
+.. literalinclude:: ../../examples/introductory_examples/example_basic_beamforming.py
+   :language: python
+   :start-after: # Plot beamforming map.
+   :end-before: # Plot microphone arrangement.
 
 .. figure:: three_source_py3_colormap.png
    :align: center
    :scale: 50%
 
-It appears that the three sources correspond to the local maxima in the map and that the relative height of two lesser maxima is -3 dB and -6 dB. These are the expected results, because the simulation that produced the data assumes source locations (relative to array center) and levels that are given in the following table:
+The same example also plots the microphone arrangement:
+
+.. literalinclude:: ../../examples/introductory_examples/example_basic_beamforming.py
+   :language: python
+   :start-after: # Plot microphone arrangement.
+
+.. figure:: array64_py3colormap.png
+   :align: center
+   :scale: 50%
+
+The map shows three local maxima at the simulated source positions. Their
+relative levels match the synthetic input data:
 
 ====== =============== ======
-Source Location        Level 
+Source Location        Level
 ====== =============== ======
 1      (-0.1,-0.1,0.3) 1 Pa
-2      (0.15,0,0.3)    0.7 Pa 
+2      (0.15,0,0.3)    0.7 Pa
 3      (0,0.1,0.3)     0.5 Pa
 ====== =============== ======
 
-as would be expected from the values given in the table above.
+Next Steps
+----------
 
-To play around with this simple example, download :download:`example_basic_beamforming.py <../../examples/introductory_examples/example_basic_beamforming.py>` change something and run it as a Python script.
+* See :ref:`lazy_evaluation` for a closer look at when Acoular actually starts
+  calculating results.
+* See :ref:`caching` for the file-based cache controls.
+* Download and modify the full scripts if you want to experiment:
 
-.. literalinclude:: ../../examples/introductory_examples/example_basic_beamforming.py
-
-To see how the simulated data is generated, read :download:`example_three_sources.py <../../examples/introductory_examples/example_three_sources.py>`. 
-
-.. literalinclude:: ../../examples/introductory_examples/example_three_sources.py
+  * :download:`example_basic_beamforming.py <../../examples/introductory_examples/example_basic_beamforming.py>`
+  * :download:`example_three_sources.py <../../examples/introductory_examples/example_three_sources.py>`

--- a/docs/user_guide/lazy_evaluation.rst
+++ b/docs/user_guide/lazy_evaluation.rst
@@ -13,6 +13,10 @@ beamforming maps, and time-domain processing chains. Lazy evaluation lets you
 assemble and adjust such a setup without repeatedly reading data or recalculating
 intermediate results.
 
+The code snippets below are taken from
+:doc:`../auto_examples/introductory_examples/example_basic_beamforming` and
+:doc:`../auto_examples/introductory_examples/example_lazy_evaluation`.
+
 The Basic Idea
 --------------
 
@@ -20,12 +24,10 @@ Most Acoular objects describe one processing step and hold references to their
 input objects. The objects form a graph or chain, but the graph is idle until a
 result is pulled from it.
 
-.. code-block:: python
-
-    import acoular as ac
-
-    ts = ac.TimeSamples(file="three_sources.h5")
-    ps = ac.PowerSpectra(source=ts, block_size=128, window="Hanning")
+.. literalinclude:: ../../examples/introductory_examples/example_basic_beamforming.py
+   :language: python
+   :start-after: # Import packages.
+   :end-before: # Calculate beamforming result.
 
 At this point, the time data is not loaded into memory and the cross-spectral
 matrix has not been calculated. The :class:`~acoular.sources.TimeSamples` object
@@ -35,9 +37,10 @@ knows how the spectra should be calculated.
 The calculation starts when a result property, method, or generator output is
 requested:
 
-.. code-block:: python
-
-    csm = ps.csm
+.. literalinclude:: ../../examples/introductory_examples/example_lazy_evaluation.py
+   :language: python
+   :start-after: # Request the cross-spectral matrix.
+   :end-before: # Request a single frequency line from the lazy result object.
 
 This access asks :class:`~acoular.spectra.PowerSpectra` for its cross-spectral
 matrix. Only then does Acoular read the source data block by block and calculate
@@ -63,42 +66,28 @@ Example: Frequency-Domain Beamforming
 -------------------------------------
 
 The frequency-domain beamforming workflow in the getting-started tutorial is a
-good example. First, define the input data and spectral processing:
+good example. First, define the input data and spectral processing, then define
+the focus grid, microphone geometry, and steering vector. No beamforming map has
+been calculated yet.
 
-.. code-block:: python
+The beamformer result itself is also lazy per frequency. Accessing
+``bb.result`` prepares a lazy result object. Individual frequency lines are
+calculated only when they are indexed:
 
-    ts = ac.TimeSamples(file="three_sources.h5")
-    ps = ac.PowerSpectra(source=ts, block_size=128, window="Hanning")
+.. literalinclude:: ../../examples/introductory_examples/example_lazy_evaluation.py
+   :language: python
+   :start-after: # Request a single frequency line from the lazy result object.
+   :end-before: # Trigger the beamforming map calculation.
 
-Then define the focus grid, microphone geometry, and steering vector:
+In the usual workflow, the first full calculation is triggered by asking for a
+map at a frequency or frequency band:
 
-.. code-block:: python
+.. literalinclude:: ../../examples/introductory_examples/example_lazy_evaluation.py
+   :language: python
+   :start-after: # Trigger the beamforming map calculation.
+   :end-before: # Change a parameter and request the result again.
 
-    rg = ac.RectGrid(
-        x_min=-0.2,
-        x_max=0.2,
-        y_min=-0.2,
-        y_max=0.2,
-        z=-0.3,
-        increment=0.01,
-    )
-    mg = ac.MicGeom(file="array_64.xml")
-    st = ac.SteeringVector(grid=rg, mics=mg)
-
-Finally, create the frequency-domain beamformer:
-
-.. code-block:: python
-
-    bb = ac.BeamformerBase(freq_data=ps, steer=st)
-
-No beamforming map has been calculated yet. In the usual workflow, the first
-calculation is triggered by asking for a map at a frequency or frequency band:
-
-.. code-block:: python
-
-    pm = bb.synthetic(8000, 3)
-
-This single line pulls the required upstream results:
+This single request pulls the required upstream results:
 
 * :class:`~acoular.spectra.PowerSpectra` calculates the cross-spectral matrix if
   it is not already available.
@@ -106,16 +95,6 @@ This single line pulls the required upstream results:
   needed for the requested third-octave band.
 * The return value is reshaped to the grid shape and contains the beamforming
   map for that band.
-
-The beamformer result itself is also lazy per frequency. Accessing
-``bb.result`` prepares a lazy result object. Individual frequency lines are
-calculated only when they are indexed:
-
-.. code-block:: python
-
-    result = bb.result
-    one_line = result[10]      # calculates frequency index 10 if needed
-    several = result[10:20]    # calculates missing indices in that slice
 
 If file caching is active, calculated frequency-domain results can also be
 stored and reused. Lazy evaluation decides *when* a calculation is needed;
@@ -134,25 +113,25 @@ The following chain performs time-domain delay-and-sum beamforming with
 signal per grid point. The chain then filters the beamformer output, squares it,
 and averages it block-wise to create source maps.
 
-.. code-block:: python
-
-    bt = ac.BeamformerTime(source=ts, steer=st)
-    ft = ac.FiltOctave(source=bt, band=4000)
-    pt = ac.TimePower(source=ft)
-    avg = ac.Average(source=pt, num_per_average=1024)
+.. literalinclude:: ../../examples/introductory_examples/example_lazy_evaluation.py
+   :language: python
+   :start-after: # Build a lazy time-domain processing chain.
+   :end-before: # Create the generator.
 
 The chain is now configured, but no samples have been processed. Even the next
 line only creates a generator object:
 
-.. code-block:: python
-
-    blocks = avg.result(num=1)
+.. literalinclude:: ../../examples/introductory_examples/example_lazy_evaluation.py
+   :language: python
+   :start-after: # Create the generator.
+   :end-before: # Pull the first block from the generator.
 
 The first processing work starts when output is pulled from the generator:
 
-.. code-block:: python
-
-    first_map = next(blocks)
+.. literalinclude:: ../../examples/introductory_examples/example_lazy_evaluation.py
+   :language: python
+   :start-after: # Pull the first block from the generator.
+   :end-before: # Add explicit caching to the lazy chain.
 
 To create ``first_map``, Acoular pulls one averaged block from
 :class:`~acoular.process.Average`. That object pulls the required number of
@@ -160,15 +139,6 @@ blocks from :class:`~acoular.tprocess.TimePower`, which pulls from
 :class:`~acoular.tprocess.FiltOctave`, which pulls from
 :class:`~acoular.tbeamform.BeamformerTime`, which finally pulls time samples
 from ``ts``.
-
-Iterating over the generator continues the chain block by block:
-
-.. code-block:: python
-
-    for maps in avg.result(num=1):
-        # maps contains one averaged beamforming map per output block.
-        # Each loop iteration pulls only the data needed for that block.
-        pass
 
 This pull-based model keeps memory use bounded for long recordings. The full
 time history does not need to be present in memory at once.
@@ -180,10 +150,9 @@ Lazy evaluation and caching are often used together in time-domain workflows.
 Adding :class:`~acoular.process.Cache` at the end of the chain stores blocks
 while they are pulled for the first time:
 
-.. code-block:: python
-
-    cached_avg = ac.Cache(source=avg)
-    first_map = next(cached_avg.result(num=1))
+.. literalinclude:: ../../examples/introductory_examples/example_lazy_evaluation.py
+   :language: python
+   :start-after: # Add explicit caching to the lazy chain.
 
 The chain is still lazy. The cache does not force calculation when it is created;
 it only changes what happens when blocks are requested. On the first pass,
@@ -197,10 +166,10 @@ Because Acoular objects are trait based, changing a relevant trait changes the
 state of the processing object. The next request uses the new settings and
 recalculates the affected result.
 
-.. code-block:: python
-
-    ps.block_size = 256
-    pm = bb.synthetic(8000, 3)
+.. literalinclude:: ../../examples/introductory_examples/example_lazy_evaluation.py
+   :language: python
+   :start-after: # Change a parameter and request the result again.
+   :end-before: # Build a lazy time-domain processing chain.
 
 Here, changing ``ps.block_size`` changes the spectral processing. The next
 request for ``bb.synthetic`` must use a cross-spectral matrix calculated with the

--- a/docs/user_guide/lazy_evaluation.rst
+++ b/docs/user_guide/lazy_evaluation.rst
@@ -40,7 +40,7 @@ requested:
 .. literalinclude:: ../../examples/introductory_examples/example_lazy_evaluation.py
    :language: python
    :start-after: # Request the cross-spectral matrix.
-   :end-before: # Request a single frequency line from the lazy result object.
+   :end-before: # %%
 
 This access asks :class:`~acoular.spectra.PowerSpectra` for its cross-spectral
 matrix. Only then does Acoular read the source data block by block and calculate
@@ -77,7 +77,7 @@ calculated only when they are indexed:
 .. literalinclude:: ../../examples/introductory_examples/example_lazy_evaluation.py
    :language: python
    :start-after: # Request a single frequency line from the lazy result object.
-   :end-before: # Trigger the beamforming map calculation.
+   :end-before: # %%
 
 In the usual workflow, the first full calculation is triggered by asking for a
 map at a frequency or frequency band:
@@ -85,8 +85,7 @@ map at a frequency or frequency band:
 .. literalinclude:: ../../examples/introductory_examples/example_lazy_evaluation.py
    :language: python
    :start-after: # Trigger the beamforming map calculation.
-   :end-before: # Change a parameter and request the result again.
-
+   :end-before: # %%
 This single request pulls the required upstream results:
 
 * :class:`~acoular.spectra.PowerSpectra` calculates the cross-spectral matrix if
@@ -116,22 +115,20 @@ and averages it block-wise to create source maps.
 .. literalinclude:: ../../examples/introductory_examples/example_lazy_evaluation.py
    :language: python
    :start-after: # Build a lazy time-domain processing chain.
-   :end-before: # Create the generator.
-
+   :end-before: # %%
 The chain is now configured, but no samples have been processed. Even the next
 line only creates a generator object:
 
 .. literalinclude:: ../../examples/introductory_examples/example_lazy_evaluation.py
    :language: python
    :start-after: # Create the generator.
-   :end-before: # Pull the first block from the generator.
-
+   :end-before: # %%
 The first processing work starts when output is pulled from the generator:
 
 .. literalinclude:: ../../examples/introductory_examples/example_lazy_evaluation.py
    :language: python
    :start-after: # Pull the first block from the generator.
-   :end-before: # Add explicit caching to the lazy chain.
+   :end-before: # %%
 
 To create ``first_map``, Acoular pulls one averaged block from
 :class:`~acoular.process.Average`. That object pulls the required number of
@@ -169,7 +166,7 @@ recalculates the affected result.
 .. literalinclude:: ../../examples/introductory_examples/example_lazy_evaluation.py
    :language: python
    :start-after: # Change a parameter and request the result again.
-   :end-before: # Build a lazy time-domain processing chain.
+   :end-before: # %%
 
 Here, changing ``ps.block_size`` changes the spectral processing. The next
 request for ``bb.synthetic`` must use a cross-spectral matrix calculated with the

--- a/examples/introductory_examples/example_basic_beamforming.py
+++ b/examples/introductory_examples/example_basic_beamforming.py
@@ -16,6 +16,7 @@ Beamforming and generates a map of the three sources.
 from pathlib import Path
 
 import acoular as ac
+
 import matplotlib.pyplot as plt
 
 # Define paths to geometry and data.

--- a/examples/introductory_examples/example_basic_beamforming.py
+++ b/examples/introductory_examples/example_basic_beamforming.py
@@ -12,29 +12,39 @@ Beamforming and generates a map of the three sources.
     :doc:`example_three_sources` example.
 """
 
+# Import packages.
 from pathlib import Path
 
 import acoular as ac
-
 import matplotlib.pyplot as plt
 
+# Define paths to geometry and data.
 micgeofile = Path(ac.__file__).parent / 'xml' / 'array_64.xml'
 datafile = Path('three_sources.h5')
 assert datafile.exists(), 'Data file not found, run example_three_sources.py first'
 
+# Load geometry and time data.
 mg = ac.MicGeom(file=micgeofile)
 ts = ac.TimeSamples(file=datafile)
+
+# Define spectral processing.
 ps = ac.PowerSpectra(source=ts, block_size=128, window='Hanning')
+
+# Define grid and steering vector.
 rg = ac.RectGrid(x_min=-0.2, x_max=0.2, y_min=-0.2, y_max=0.2, z=-0.3, increment=0.01)
 st = ac.SteeringVector(grid=rg, mics=mg)
+
+# Calculate beamforming result.
 bb = ac.BeamformerBase(freq_data=ps, steer=st)
 pm = bb.synthetic(8000, 3)
 Lm = ac.L_p(pm)
 
+# Plot beamforming map.
 plt.figure(1)
 plt.imshow(Lm.T, origin='lower', vmin=Lm.max() - 10, extent=rg.extent, interpolation='bicubic')
 plt.colorbar()
 
+# Plot microphone arrangement.
 plt.figure(2)
 plt.plot(mg.pos[0], mg.pos[1], 'o')
 plt.axis('equal')

--- a/examples/introductory_examples/example_caching.py
+++ b/examples/introductory_examples/example_caching.py
@@ -1,0 +1,63 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) Acoular Development Team.
+# ------------------------------------------------------------------------------
+# %%
+"""Caching -- Reuse calculated results.
+======================================
+
+Shows how to configure Acoular's file-based cache, how object-level caching
+interacts with the global caching mode, and how to explicitly cache a lazy
+time-domain processing chain.
+"""
+
+# Import packages.
+from pathlib import Path
+
+import acoular as ac
+
+# %%
+# Configure cache directory, backend, and global mode.
+cache_dir = Path('cache')
+ac.config.cache_dir = str(cache_dir)
+ac.config.h5library = 'pytables'
+ac.config.global_caching = 'individual'
+
+# %%
+# Define shared geometry and input data.
+micgeofile = Path(ac.__file__).parent / 'xml' / 'array_64.xml'
+datafile = Path('three_sources.h5')
+mg = ac.MicGeom(file=micgeofile)
+
+if not datafile.exists():
+    ac.demo.create_three_sources(mg, h5savefile=datafile)
+
+ts = ac.TimeSamples(file=datafile)
+rg = ac.RectGrid(x_min=-0.2, x_max=0.2, y_min=-0.2, y_max=0.2, z=-0.3, increment=0.01)
+st = ac.SteeringVector(grid=rg, mics=mg)
+
+# %%
+# Use object-level caching controls.
+ps = ac.PowerSpectra(source=ts, block_size=128, window='Hanning')
+ps.cached = False
+
+bb = ac.BeamformerBase(freq_data=ps, steer=st, cached=True)
+pm = bb.synthetic(8000, 3)
+
+# %%
+# Check the generated cache file.
+cache_file = cache_dir / 'three_sources_cache.h5'
+
+# %%
+# Force recalculation in overwrite mode.
+ac.config.global_caching = 'overwrite'
+pm_overwrite = bb.synthetic(8000, 3)
+ac.config.global_caching = 'individual'
+
+# %%
+# Explicitly cache a time-domain processing chain.
+bt = ac.BeamformerTime(source=ts, steer=st)
+ft = ac.FiltOctave(source=bt, band=4000)
+pt = ac.TimePower(source=ft)
+avg = ac.Average(source=pt, num_per_average=1024)
+cached_avg = ac.Cache(source=avg)
+first_map = next(cached_avg.result(num=1))

--- a/examples/introductory_examples/example_lazy_evaluation.py
+++ b/examples/introductory_examples/example_lazy_evaluation.py
@@ -1,0 +1,72 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) Acoular Development Team.
+# ------------------------------------------------------------------------------
+# %%
+"""Lazy evaluation -- Build first, calculate on demand.
+=======================================================
+
+Demonstrates how Acoular objects stay idle until a result is actually requested.
+The example covers both frequency-domain beamforming and a time-domain
+processing chain.
+"""
+
+# Import packages.
+from pathlib import Path
+
+import acoular as ac
+
+# %%
+# Define shared geometry and input data.
+micgeofile = Path(ac.__file__).parent / 'xml' / 'array_64.xml'
+datafile = Path('three_sources.h5')
+mg = ac.MicGeom(file=micgeofile)
+
+if not datafile.exists():
+    ac.demo.create_three_sources(mg, h5savefile=datafile)
+
+ts = ac.TimeSamples(file=datafile)
+rg = ac.RectGrid(x_min=-0.2, x_max=0.2, y_min=-0.2, y_max=0.2, z=-0.3, increment=0.01)
+st = ac.SteeringVector(grid=rg, mics=mg)
+
+# %%
+# Build the frequency-domain processing objects.
+ps = ac.PowerSpectra(source=ts, block_size=128, window='Hanning')
+bb = ac.BeamformerBase(freq_data=ps, steer=st)
+
+# %%
+# Request the cross-spectral matrix.
+csm = ps.csm
+
+# %%
+# Request a single frequency line from the lazy result object.
+result = bb.result
+one_line = result[10]
+
+# %%
+# Trigger the beamforming map calculation.
+pm = bb.synthetic(8000, 3)
+
+# %%
+# Change a parameter and request the result again.
+ps.block_size = 256
+pm_updated = bb.synthetic(8000, 3)
+
+# %%
+# Build a lazy time-domain processing chain.
+bt = ac.BeamformerTime(source=ts, steer=st)
+ft = ac.FiltOctave(source=bt, band=4000)
+pt = ac.TimePower(source=ft)
+avg = ac.Average(source=pt, num_per_average=1024)
+
+# %%
+# Create the generator.
+blocks = avg.result(num=1)
+
+# %%
+# Pull the first block from the generator.
+first_map = next(blocks)
+
+# %%
+# Add explicit caching to the lazy chain.
+cached_avg = ac.Cache(source=avg)
+first_cached_map = next(cached_avg.result(num=1))

--- a/examples/introductory_examples/example_three_sources.py
+++ b/examples/introductory_examples/example_three_sources.py
@@ -26,16 +26,19 @@ Source Location        Level
 
 """
 
+# Import packages.
 from pathlib import Path
 
 import acoular as ac
 
+# Define simulation setup.
 sfreq = 51200
 duration = 1
 num_samples = duration * sfreq
 micgeofile = Path(ac.__file__).parent / 'xml' / 'array_64.xml'
 h5savefile = Path('three_sources.h5')
 
+# Generate and store the example data.
 m = ac.MicGeom(file=micgeofile)
 n1 = ac.WNoiseGenerator(sample_freq=sfreq, num_samples=num_samples, seed=1)
 n2 = ac.WNoiseGenerator(sample_freq=sfreq, num_samples=num_samples, seed=2, rms=0.7)

--- a/tests/unittests/test_user_guide_sources.py
+++ b/tests/unittests/test_user_guide_sources.py
@@ -1,6 +1,5 @@
-from pathlib import Path
 import re
-
+from pathlib import Path
 
 DOCS_ROOT = Path(__file__).resolve().parents[2] / 'docs' / 'user_guide'
 USER_GUIDE_PAGES = sorted(p for p in DOCS_ROOT.glob('*.rst') if p.name != 'index.rst')

--- a/tests/unittests/test_user_guide_sources.py
+++ b/tests/unittests/test_user_guide_sources.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+import re
+
+
+DOCS_ROOT = Path(__file__).resolve().parents[2] / 'docs' / 'user_guide'
+USER_GUIDE_PAGES = sorted(p for p in DOCS_ROOT.glob('*.rst') if p.name != 'index.rst')
+LITERALINCLUDE_RE = re.compile(r'^\.\. literalinclude::\s+(?P<target>.+)$')
+
+
+def test_user_guide_uses_example_literalincludes_for_runnable_python():
+    """User guide pages should include runnable Python from examples, not inline blocks."""
+    for page in USER_GUIDE_PAGES:
+        text = page.read_text()
+        assert '.. ipython::' not in text, f'{page} still contains ipython blocks'
+        assert '.. code-block:: python' not in text, f'{page} still contains inline python blocks'
+        assert '.. code:: python' not in text, f'{page} still contains inline python code directives'
+
+
+def test_user_guide_literalincludes_point_to_examples():
+    """All user guide code snippets should come from runnable example scripts."""
+    for page in USER_GUIDE_PAGES:
+        targets = []
+        for line in page.read_text().splitlines():
+            match = LITERALINCLUDE_RE.match(line.strip())
+            if match:
+                targets.append(match.group('target'))
+
+        assert targets, f'{page} does not include any example snippets'
+
+        for target in targets:
+            assert target.startswith('../../examples/'), f'{page} includes non-example snippet: {target}'
+            snippet_path = (page.parent / target).resolve()
+            assert snippet_path.exists(), f'{page} includes missing file: {target}'
+            assert snippet_path.name.startswith('example_'), f'{page} includes non-example file: {target}'


### PR DESCRIPTION
To avoid untested/drifting documentation, all code in the user guide should be tested against the latest Acoular version. I think the best way is to only allow including code snippets from `examples/` in the user guide. For code that is not yet available, an example should be added in the future. I've updated the current guide to follow this idea. All code blocks are included with `..literalinclude`