### PR TITLE
Fix Average to save memory in its source processing

### DIFF
--- a/acoular/process.py
+++ b/acoular/process.py
@@ -159,8 +159,8 @@ class Average(InOut):
         ----------
         num : :class:`int`
             The number of averaged blocks to yield at a time. Each block contains the average over
-            :attr:`num_per_average` time samples or frequency snapshots. The last block may be
-            shorter than the specified size if the remaining data is insufficient.
+            :attr:`num_per_average` time samples or frequency snapshots. The last yielded block
+            may contain fewer than ``num`` averages.
 
         Yields
         ------
@@ -180,14 +180,34 @@ class Average(InOut):
               :attr:`num_per_average` frequency snapshots.
         - The generator will stop yielding when the source data is exhausted.
         - If the source provides fewer than ``num * num_per_average`` samples,
-          the final block may be smaller than the requested ``num`` size.
+          the final yielded block may be smaller than the requested ``num`` size.
+        - If the source provides a final block with fewer than :attr:`num_per_average` samples,
+          these samples are discarded. If the source provides fewer than
+          :attr:`num_per_average` samples in total, nothing is yielded.
         """
         nav = self.num_per_average
-        for temp in self.source.result(num * nav):
+        out = None
+        outnum = 0
+        # fetches data blocks from source, nav must not be too large
+        for temp in self.source.result(nav):
             ns, nc = temp.shape
-            nso = int(ns / nav)
-            if nso > 0:
-                yield temp[: nso * nav].reshape((nso, -1, nc)).mean(axis=1)
+            # is this a complete block of `nav` samples ?
+            if ns == nav:
+                avg = temp.mean(axis=0)
+                # create accumulator if not exists
+                if out is None:
+                    out = np.empty((num, nc), dtype=avg.dtype)
+                # add one output sample
+                out[outnum] = avg
+                outnum += 1
+                # block complete -> yield it and create new one
+                if outnum == num:
+                    yield out
+                    out = np.empty_like(out)
+                    outnum = 0
+        # last block of data
+        if outnum:
+            yield out[:outnum]
 
 
 class Cache(InOut):

--- a/acoular/process.py
+++ b/acoular/process.py
@@ -192,19 +192,19 @@ class Average(InOut):
         for temp in self.source.result(nav):
             ns, nc = temp.shape
             # is this a complete block of `nav` samples ?
-            if ns == nav:
-                avg = temp.mean(axis=0)
-                # create accumulator if not exists
-                if out is None:
-                    out = np.empty((num, nc), dtype=avg.dtype)
-                # add one output sample
-                out[outnum] = avg
-                outnum += 1
-                # block complete -> yield it and create new one
-                if outnum == num:
-                    yield out
-                    out = None
-                    outnum = 0
+            if ns != nav:
+                continue
+            # create accumulator if not exists
+            if out is None:
+                out = np.empty((num, nc), dtype=temp.dtype)
+            # add one output sample
+            temp.mean(axis=0, out=out[outnum])
+            outnum += 1
+            # block complete -> yield it and create new one
+            if outnum == num:
+                yield out
+                out = None
+                outnum = 0
         # last block of data
         if outnum:
             yield out[:outnum]

--- a/acoular/process.py
+++ b/acoular/process.py
@@ -203,7 +203,7 @@ class Average(InOut):
                 # block complete -> yield it and create new one
                 if outnum == num:
                     yield out
-                    out = np.empty_like(out)
+                    out = None
                     outnum = 0
         # last block of data
         if outnum:

--- a/docs/news/index.rst
+++ b/docs/news/index.rst
@@ -12,6 +12,7 @@ Upcoming
         * renames :meth:`~acoular.environments.Environment._r` to :meth:`~acoular.environments.Environment.apparent_r`
         * lazy import of sklearn to speed import of the package
         * lazy numba jits to speed up import of the package
+        * fixes :meth:`~acoular.process.Average.result` to fetch smaller blocks in order not to demand too much memory in the processing of its source
 
 26.04
 ------------------------


### PR DESCRIPTION
When `Average.result` fetches its data from its source it does so using possibly very large block sizes. This could overwhelm the processing in e.g. `BeamformerTimeTrajSq` by allocating too much memory (and eventually many many GB - more than the computer might have). This is fixed by just pulling as many samples as needed to average over.

### Checklist
<!-- Please make sure that your pull request checks all the boxes. -->
- [x] I have read the [Contributing](https://www.acoular.org/contributing/index.html) section.
- [x] My branch is up-to-date with the *master* branch of the [Acoular repository](https://github.com/acoular/acoular).
- [x] My changes fulfill the [Code Quality](https://www.acoular.org/contributing/quality.html) standards.
- [x] I have updated the [What's new](https://github.com/acoular/acoular/blob/master/docs/news/index.rst) section explaining my changes.
