### PR TITLE
avoid copying avg

### DIFF
--- a/acoular/process.py
+++ b/acoular/process.py
@@ -201,14 +201,14 @@ class Average(InOut):
             # create accumulator if not exists
             if out is None:
                 out = np.empty((num, nc), dtype=dtype)
-                # add one output sample
-                temp.mean(axis=0, out=out[outnum])
-                outnum += 1
-                # block complete -> yield it and create new one
-                if outnum == num:
-                    yield out
-                    out = None
-                    outnum = 0
+            # add one output sample
+            temp.mean(axis=0, out=out[outnum])
+            outnum += 1
+            # block complete -> yield it and create new one
+            if outnum == num:
+                yield out
+                out = None
+                outnum = 0
         # last block of data
         if outnum:
             yield out[:outnum]

--- a/acoular/process.py
+++ b/acoular/process.py
@@ -187,18 +187,22 @@ class Average(InOut):
         """
         nav = self.num_per_average
         out = None
+        dtype = None
         outnum = 0
         # fetches data blocks from source, nav must not be too large
         for temp in self.source.result(nav):
             ns, nc = temp.shape
             # is this a complete block of `nav` samples ?
-            if ns == nav:
-                avg = temp.mean(axis=0)
-                # create accumulator if not exists
-                if out is None:
-                    out = np.empty((num, nc), dtype=avg.dtype)
+            if ns != nav:
+                continue
+            # determine dtype of the mean once
+            if dtype is None:
+                dtype = np.empty((), dtype=temp.dtype).mean().dtype
+            # create accumulator if not exists
+            if out is None:
+                out = np.empty((num, nc), dtype=dtype)
                 # add one output sample
-                out[outnum] = avg
+                temp.mean(axis=0, out=out[outnum])
                 outnum += 1
                 # block complete -> yield it and create new one
                 if outnum == num:

--- a/acoular/process.py
+++ b/acoular/process.py
@@ -187,7 +187,6 @@ class Average(InOut):
         """
         nav = self.num_per_average
         out = None
-        dtype = None
         outnum = 0
         # fetches data blocks from source, nav must not be too large
         for temp in self.source.result(nav):
@@ -195,12 +194,9 @@ class Average(InOut):
             # is this a complete block of `nav` samples ?
             if ns != nav:
                 continue
-            # determine dtype of the mean once
-            if dtype is None:
-                dtype = np.empty((), dtype=temp.dtype).mean().dtype
             # create accumulator if not exists
             if out is None:
-                out = np.empty((num, nc), dtype=dtype)
+                out = np.empty((num, nc), dtype=temp.dtype)
             # add one output sample
             temp.mean(axis=0, out=out[outnum])
             outnum += 1


### PR DESCRIPTION
This will avoid instantiating `avg` and copying that into `out`. Also, I removed some nesting of if clauses, hoping that its easier to grasp.